### PR TITLE
Added input/output validation and passed execution-name to worker

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,8 +30,9 @@ sfncli -activityname sleep-100 -region us-west-2 -workername sleep-worker -cmd s
 - On startup, call [`CreateActivity`](http://docs.aws.amazon.com/step-functions/latest/apireference/API_CreateActivity.html) to register an [Activity](http://docs.aws.amazon.com/step-functions/latest/dg/concepts-activities.html) with Step Functions.
 - Begin polling [`GetActivityTask`](http://docs.aws.amazon.com/step-functions/latest/apireference/API_GetActivityTask.html) for tasks.
 - Get a task. Take the JSON input for the task and
-  - if it's an array, use this as the args to the command.
-  - if it's anything else (e.g. JSON object), it's currently not supported
+  - if it's a JSON object, use this as the last arg to the command.
+  - if it's anything else (e.g. JSON array), an error is thown
+  - if JSON object has a `_EXECUTION_NAME` property, an corresponding env var called `_EXECUTION_NAME` is add to the sub-process enviornment
 - Start [`SendTaskHeartbeat`](http://docs.aws.amazon.com/step-functions/latest/apireference/API_SendTaskHeartbeat.html) loop.
 - Call [`SendTaskFailure`](http://docs.aws.amazon.com/step-functions/latest/apireference/API_SendTaskFailure.html) / [`SendTaskSuccess`](http://docs.aws.amazon.com/step-functions/latest/apireference/API_SendTaskSuccess.html) when command returns.
 
@@ -66,10 +67,10 @@ Note that you will need to replace the `Resource` above to reflect the correct A
 Start an execution of the state machine (again replacing the ARN below with the correct account ID):
 
 ```
-aws --region us-west-2 stepfunctions start-execution --state-machine-arn arn:aws:states:us-west-2:589690932525:stateMachine:test-state-machine  --input '["hello", "world"]'
+aws --region us-west-2 stepfunctions start-execution --state-machine-arn arn:aws:states:us-west-2:589690932525:stateMachine:test-state-machine  --input '{"hello": "world"}'
 ```
 
-You should see `echo` run with the arguments "hello" and "world".
+You should see `echo` run with the argument `{"hello": "world"}`.
 
 ## Usage
 

--- a/cmd/sfncli/runner.go
+++ b/cmd/sfncli/runner.go
@@ -58,10 +58,7 @@ func (t TaskRunner) Process(ctx context.Context) error {
 	cmd.Stderr = io.MultiWriter(os.Stderr, stderrbuf)
 	cmd.Stdout = io.MultiWriter(os.Stdout, stdoutbuf)
 
-	log.InfoD("exec-command-start", map[string]interface{}{
-		"args": t.args,
-		"cmd":  t.cmd,
-	})
+	log.InfoD("exec-command-start", logger.M{"args": t.args, "cmd": t.cmd})
 	if err := cmd.Run(); err != nil {
 		log.InfoD("exec-command-err", logger.M{"error": err.Error()})
 		if _, e := t.sfnapi.SendTaskFailureWithContext(ctx, &sfn.SendTaskFailureInput{

--- a/cmd/sfncli/runner.go
+++ b/cmd/sfncli/runner.go
@@ -36,7 +36,7 @@ func NewTaskRunner(
 	}
 	executionName, _ := taskInput["_EXECUTION_NAME"].(string)
 
-	marshaledJob, err := json.Marshal(taskInput)
+	marshaledInput, err := json.Marshal(taskInput)
 	if err != nil {
 		return TaskRunner{}, err
 	}
@@ -46,7 +46,7 @@ func NewTaskRunner(
 		taskToken:     taskToken,
 		executionName: executionName,
 		cmd:           cmd,
-		args:          append(args, string(marshaledJob)),
+		args:          append(args, string(marshaledInput)),
 	}, nil
 }
 

--- a/cmd/sfncli/runner.go
+++ b/cmd/sfncli/runner.go
@@ -23,41 +23,55 @@ type TaskRunner struct {
 	sfnapi        sfniface.SFNAPI
 	taskToken     string
 	cmd           string
-	args          []string
 	executionName string
 }
 
-func NewTaskRunner(
-	cmd string, args []string, sfnapi sfniface.SFNAPI, input, taskToken string,
-) (TaskRunner, error) {
+func NewTaskRunner(cmd string, sfnapi sfniface.SFNAPI, taskToken string) TaskRunner {
+	return TaskRunner{
+		sfnapi:    sfnapi,
+		taskToken: taskToken,
+		cmd:       cmd,
+	}
+}
+
+func (t TaskRunner) handleProcessError(ctx context.Context, title string, err error) error {
+	log.ErrorD(title, logger.M{"error": err.Error()})
+
+	_, sendErr := t.sfnapi.SendTaskFailureWithContext(ctx, &sfn.SendTaskFailureInput{
+		Cause:     aws.String(err.Error()),
+		TaskToken: &t.taskToken,
+	})
+	if sendErr != nil {
+		return fmt.Errorf("error sending task failure: %s", sendErr)
+	}
+
+	return err
+}
+
+// Process runs the underlying cmd with the appropriate
+// environment and command line params
+func (t TaskRunner) Process(ctx context.Context, args []string, input string) error {
+	if t.sfnapi == nil { // if New failed :-/
+		return t.handleProcessError(ctx, "process-init", fmt.Errorf("NewTaskFailure -- nil sfnapi"))
+	}
+
 	var taskInput map[string]interface{}
 	if err := json.Unmarshal([]byte(input), &taskInput); err != nil {
-		return TaskRunner{}, fmt.Errorf("Input must be a json object: %s", err)
+		return t.handleProcessError(
+			ctx, "process-input", fmt.Errorf("Input must be a json object: %s", err),
+		)
 	}
 	executionName, _ := taskInput["_EXECUTION_NAME"].(string)
 
 	marshaledInput, err := json.Marshal(taskInput)
 	if err != nil {
-		return TaskRunner{}, err
+		return t.handleProcessError(ctx, "process-input", err)
 	}
 
-	return TaskRunner{
-		sfnapi:        sfnapi,
-		taskToken:     taskToken,
-		executionName: executionName,
-		cmd:           cmd,
-		args:          append(args, string(marshaledInput)),
-	}, nil
-}
+	args = append(args, string(marshaledInput))
 
-// Process runs the underlying cmd with the appropriate
-// environment and command line params
-func (t TaskRunner) Process(ctx context.Context) error {
-	if t.sfnapi == nil {
-		return fmt.Errorf("NewTaskFailure -- nil sfnapi") // if New failed :-/
-	}
-	cmd := exec.CommandContext(ctx, t.cmd, t.args...)
-	cmd.Env = append(os.Environ(), "_EXECUTION_NAME="+t.executionName)
+	cmd := exec.CommandContext(ctx, t.cmd, args...)
+	cmd.Env = append(os.Environ(), "_EXECUTION_NAME="+executionName)
 
 	// Write the stdout and stderr of the process to both this process' stdout and stderr
 	// and also write to a byte buffer so that we can send the result to step functions
@@ -66,16 +80,9 @@ func (t TaskRunner) Process(ctx context.Context) error {
 	cmd.Stderr = io.MultiWriter(os.Stderr, stderrbuf)
 	cmd.Stdout = io.MultiWriter(os.Stdout, stdoutbuf)
 
-	log.InfoD("exec-command-start", logger.M{"args": t.args, "cmd": t.cmd})
+	log.InfoD("exec-command-start", logger.M{"args": args, "cmd": t.cmd})
 	if err := cmd.Run(); err != nil {
-		log.InfoD("exec-command-err", logger.M{"error": err.Error()})
-		if _, e := t.sfnapi.SendTaskFailureWithContext(ctx, &sfn.SendTaskFailureInput{
-			Cause:     aws.String(stderrbuf.String()),
-			TaskToken: &t.taskToken,
-		}); e != nil {
-			return fmt.Errorf("error sending task failure: %s", e)
-		}
-		return err
+		return t.handleProcessError(ctx, "exec-command-err", err)
 	}
 	log.Info("exec-command-end")
 
@@ -83,13 +90,15 @@ func (t TaskRunner) Process(ctx context.Context) error {
 	output := stdoutbuf.String()
 	var out map[string]interface{}
 	if err := json.Unmarshal([]byte(output), &out); err != nil {
-		return fmt.Errorf("Worker must output json object to stdout: %s", err)
+		return t.handleProcessError(
+			ctx, "process-output", fmt.Errorf("Worker must output json object to stdout: %s", err),
+		)
 	}
-	out["_EXECUTION_NAME"] = t.executionName
+	out["_EXECUTION_NAME"] = executionName
 
 	marshaledOut, err := json.Marshal(out)
 	if err != nil {
-		return err
+		return t.handleProcessError(ctx, "process-output", err)
 	}
 	_, err = t.sfnapi.SendTaskSuccessWithContext(ctx, &sfn.SendTaskSuccessInput{
 		Output:    aws.String(string(marshaledOut)),

--- a/cmd/sfncli/sfncli.go
+++ b/cmd/sfncli/sfncli.go
@@ -127,23 +127,8 @@ func main() {
 
 			// Run the command. Treat unprocessed args (flag.Args()) as additional args to
 			// send to the command on every invocation of the command
-			taskRunner, err := NewTaskRunner(*cmd, flag.Args(), sfnapi, input, token)
-			if err != nil {
-				log.ErrorD("process-start", logger.M{"error": err.Error()})
-
-				_, err = sfnapi.SendTaskFailureWithContext(taskCtx, &sfn.SendTaskFailureInput{
-					Cause:     aws.String(err.Error()),
-					TaskToken: &token,
-				})
-				if err != nil {
-					log.ErrorD("process-failure", logger.M{"error": err.Error()})
-				}
-
-				taskCtxCancel()
-				continue
-			}
-
-			err = taskRunner.Process(taskCtx)
+			taskRunner := NewTaskRunner(*cmd, sfnapi, token)
+			err = taskRunner.Process(taskCtx, flag.Args(), input)
 			if err != nil {
 				log.ErrorD("process-error", logger.M{"error": err.Error()})
 				taskCtxCancel()

--- a/cmd/sfncli/sfncli.go
+++ b/cmd/sfncli/sfncli.go
@@ -127,8 +127,11 @@ func main() {
 
 			// Run the command. Treat unprocessed args (flag.Args()) as additional args to
 			// send to the command on every invocation of the command
-			taskRunner := NewTaskRunner(*cmd, flag.Args(), sfnapi, input, token)
-			if err := taskRunner.Process(taskCtx); err != nil {
+			taskRunner, err := NewTaskRunner(*cmd, flag.Args(), sfnapi, input, token)
+			if err == nil {
+				err = taskRunner.Process(taskCtx)
+			}
+			if err != nil {
 				log.ErrorD("process-error", logger.M{"error": err.Error()})
 				taskCtxCancel()
 				continue


### PR DESCRIPTION
- sfcli now validates that it's input and output are json objects
- validates that its input and output include `$execution-name`
- an env-var called `_EXECUTION_NAME` is injected into the execution context of the sub-process

Jira: https://clever.atlassian.net/browse/INFRA-2553, https://clever.atlassian.net/browse/INFRA-2526