### PR TITLE
Include execution name in logs to make debugging easier

### DIFF
--- a/cmd/sfncli/sfncli.go
+++ b/cmd/sfncli/sfncli.go
@@ -130,7 +130,6 @@ func main() {
 			taskRunner := NewTaskRunner(*cmd, sfnapi, token)
 			err = taskRunner.Process(taskCtx, flag.Args(), input)
 			if err != nil {
-				log.ErrorD("process-error", logger.M{"error": err.Error()})
 				taskCtxCancel()
 				continue
 			}


### PR DESCRIPTION
Found myself looking for this feature when confirming that cil-reliability-dashboard ran correctly last night.

It might be worth to using `wf_id` instead to be consistent with how workers log workflow_id.

cc @rgarcia @mohit 