### PR TITLE
produce useful error names

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,5 @@
 vendor/
 build/
 release/
+mockgen
+gen-go/mocksfn

--- a/Makefile
+++ b/Makefile
@@ -31,6 +31,9 @@ build:
 
 install_deps: $(GOPATH)/bin/glide
 	$(GOPATH)/bin/glide install -v
+	go build -o ./mockgen ./vendor/github.com/golang/mock/mockgen
+	rm -rf gen-go/mocksfn && mkdir -p gen-go/mocksfn
+	./mockgen -source vendor/github.com/aws/aws-sdk-go/service/sfn/sfniface/interface.go -destination gen-go/mocksfn/mocksfn.go -package mocksfn
 
 release:
 	mkdir -p release

--- a/cmd/sfncli/error_names.go
+++ b/cmd/sfncli/error_names.go
@@ -94,16 +94,16 @@ func (t TaskFailureCustomErrorName) Error() string { return t.stderr }
 
 func (t TaskFailureCustomErrorName) ErrorName() string { return t.errorName }
 
-// TaskFailureCommandOutputNotJSON is used when the output of the command is not a JSON object.
-type TaskFailureCommandOutputNotJSON struct {
-	stdout string
+// TaskFailureTaskOutputNotJSON is used when the output of the task is not a JSON object.
+type TaskFailureTaskOutputNotJSON struct {
+	output string
 }
 
-func (t TaskFailureCommandOutputNotJSON) Error() string {
-	return fmt.Sprintf("stdout not valid JSON: '%s'", t.stdout)
+func (t TaskFailureTaskOutputNotJSON) Error() string {
+	return fmt.Sprintf("stdout not valid JSON: '%s'", t.output)
 }
 
-func (t TaskFailureCommandOutputNotJSON) ErrorName() string { return "sfncli.CommandOutputNotJSON" }
+func (t TaskFailureTaskOutputNotJSON) ErrorName() string { return "sfncli.TaskOutputNotJSON" }
 
 // TaskFailureCommandKilled happens when sfncli receives SIGTERM.
 type TaskFailureCommandTerminated struct {

--- a/cmd/sfncli/error_names.go
+++ b/cmd/sfncli/error_names.go
@@ -1,0 +1,115 @@
+package main
+
+import (
+	"fmt"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/sfn"
+	"gopkg.in/Clever/kayvee-go.v6/logger"
+)
+
+// States language has the concept of "Error Names"--unique strings that correspond
+// to specific error conditions under which a state can fail:
+// https://states-language.net/spec.html#error-names
+// SFNCLI has its own set of error names that it will report when failing a task.
+// These errors are described in this file.
+
+// TaskFailureError is the error reported when failing an activity task.
+type TaskFailureError interface {
+	error
+	ErrorName() string
+}
+
+// sendTaskFailure handles sending AWS `SendTaskFailure`.
+func (t TaskRunner) sendTaskFailure(err TaskFailureError) error {
+	t.logger.ErrorD("send-task-failure", logger.M{"name": err.ErrorName(), "error": err.Error()})
+
+	// don't use SendTaskFailureWithContext, since the failure itself could be from the parent
+	// context being cancelled, but we still want to report to AWS the failure of the task.
+	_, sendErr := t.sfnapi.SendTaskFailure(&sfn.SendTaskFailureInput{
+		Cause:     aws.String(err.Error()),
+		Error:     aws.String(err.ErrorName()),
+		TaskToken: &t.taskToken,
+	})
+	if sendErr != nil {
+		t.logger.ErrorD("send-task-failure-error", logger.M{"error": err.Error()})
+	}
+	return err
+}
+
+// TaskFailureUnknown is used for any error that is unexpected or not understood completely.
+type TaskFailureUnknown struct {
+	error
+}
+
+func (t TaskFailureUnknown) ErrorName() string { return "sfncli.Unknown" }
+
+// TaskFailureTaskInputNotJSON is used when the input to the task is not a JSON object.
+type TaskFailureTaskInputNotJSON struct {
+	input string
+}
+
+func (t TaskFailureTaskInputNotJSON) Error() string {
+	return fmt.Sprintf("task input not valid JSON: '%s'", t.input)
+}
+
+func (t TaskFailureTaskInputNotJSON) ErrorName() string { return "sfncli.TaskInputNotJSON" }
+
+// TaskFailureCommandNotFound is used when the command passed to sfncli is not found.
+type TaskFailureCommandNotFound struct {
+	path string
+}
+
+func (t TaskFailureCommandNotFound) Error() string {
+	return fmt.Sprintf("command not found: '%s'", t.path)
+}
+
+func (t TaskFailureCommandNotFound) ErrorName() string { return "sfncli.CommandNotFound" }
+
+// TaskFailureCommandKilled happens when the command is sent a kill signal by the OS.
+type TaskFailureCommandKilled struct {
+	stderr string
+}
+
+func (t TaskFailureCommandKilled) Error() string { return t.stderr }
+
+func (t TaskFailureCommandKilled) ErrorName() string { return "sfncli.CommandKilled" }
+
+// TaskFailureCommandKilled happens when the command exits with a nonzero exit code and doesn't specifiy its own error name in the output.
+type TaskFailureCommandExitedNonzero struct {
+	stderr string
+}
+
+func (t TaskFailureCommandExitedNonzero) Error() string { return t.stderr }
+
+func (t TaskFailureCommandExitedNonzero) ErrorName() string { return "sfncli.CommandExitedNonzero" }
+
+// TaskFailureCustomErrorName happens when the command exits with a nonzero exit code and outputs a custom error name to stdout.
+type TaskFailureCustomErrorName struct {
+	errorName string
+	stderr    string
+}
+
+func (t TaskFailureCustomErrorName) Error() string { return t.stderr }
+
+func (t TaskFailureCustomErrorName) ErrorName() string { return t.errorName }
+
+// TaskFailureCommandOutputNotJSON is used when the output of the command is not a JSON object.
+type TaskFailureCommandOutputNotJSON struct {
+	stdout string
+}
+
+func (t TaskFailureCommandOutputNotJSON) Error() string {
+	return fmt.Sprintf("stdout not valid JSON: '%s'", t.stdout)
+}
+
+func (t TaskFailureCommandOutputNotJSON) ErrorName() string { return "sfncli.CommandOutputNotJSON" }
+
+// TaskFailureCommandKilled happens when sfncli receives SIGTERM.
+type TaskFailureCommandTerminated struct {
+	stderr string
+}
+
+func (t TaskFailureCommandTerminated) Error() string { return t.stderr }
+
+func (t TaskFailureCommandTerminated) ErrorName() string { return "sfncli.CommandTerminated" }

--- a/cmd/sfncli/runner.go
+++ b/cmd/sfncli/runner.go
@@ -99,12 +99,12 @@ func (t *TaskRunner) Process(ctx context.Context, args []string, input string) e
 		case *os.PathError:
 			return t.sendTaskFailure(TaskFailureCommandNotFound{path: err.Path})
 		case *exec.ExitError:
+			if customErrorName != "" {
+				return t.sendTaskFailure(TaskFailureCustomErrorName{errorName: customErrorName, stderr: stderr})
+			}
 			status := err.ProcessState.Sys().(syscall.WaitStatus)
 			switch {
 			case status.Exited() && status.ExitStatus() > 0:
-				if customErrorName != "" {
-					return t.sendTaskFailure(TaskFailureCustomErrorName{errorName: customErrorName, stderr: stderr})
-				}
 				return t.sendTaskFailure(TaskFailureCommandExitedNonzero{stderr: stderr})
 			case status.Signaled() && status.Signal() == syscall.SIGKILL:
 				return t.sendTaskFailure(TaskFailureCommandKilled{stderr: stderr})

--- a/cmd/sfncli/runner.go
+++ b/cmd/sfncli/runner.go
@@ -3,10 +3,15 @@ package main
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"os"
 	"os/exec"
+	"os/signal"
+	"strings"
+	"syscall"
+	"time"
 
 	"github.com/armon/circbuf"
 	"github.com/aws/aws-sdk-go/aws"
@@ -20,9 +25,12 @@ const maxTaskOutputLength = 32768
 const maxTaskFailureCauseLength = 32768
 
 type TaskRunner struct {
-	sfnapi    sfniface.SFNAPI
-	taskToken string
-	cmd       string
+	sfnapi          sfniface.SFNAPI
+	taskToken       string
+	cmd             string
+	logger          logger.KayveeLogger
+	execCmd         *exec.Cmd
+	receivedSigterm bool
 }
 
 func NewTaskRunner(cmd string, sfnapi sfniface.SFNAPI, taskToken string) TaskRunner {
@@ -30,89 +38,147 @@ func NewTaskRunner(cmd string, sfnapi sfniface.SFNAPI, taskToken string) TaskRun
 		sfnapi:    sfnapi,
 		taskToken: taskToken,
 		cmd:       cmd,
+		logger:    logger.New("sfncli"),
 	}
 }
 
-func (t TaskRunner) handleProcessError(
-	ctx context.Context, executionName, title string, err error,
-) error {
-	log.ErrorD(title, logger.M{"error": err.Error(), "execution_name": executionName})
-
-	_, sendErr := t.sfnapi.SendTaskFailureWithContext(ctx, &sfn.SendTaskFailureInput{
-		Cause:     aws.String(err.Error()),
-		TaskToken: &t.taskToken,
-	})
-	if sendErr != nil {
-		return fmt.Errorf("error sending task failure: %s", sendErr)
-	}
-
-	return err
-}
-
-// Process runs the underlying cmd with the appropriate
-// environment and command line params
-func (t TaskRunner) Process(ctx context.Context, args []string, input string) error {
+// Process runs the underlying command.
+// The command inherits the environment of the parent process.
+// Any signals sent to parent process will be forwarded to the command.
+// If the context is canceled, the command is killed.
+func (t *TaskRunner) Process(ctx context.Context, args []string, input string) error {
 	if t.sfnapi == nil { // if New failed :-/
-		return t.handleProcessError(
-			ctx, "process-init", "unknown", fmt.Errorf("NewTaskFailure -- nil sfnapi"),
-		)
+		return t.sendTaskFailure(TaskFailureUnknown{errors.New("nil sfnapi")})
 	}
 
 	var taskInput map[string]interface{}
 	if err := json.Unmarshal([]byte(input), &taskInput); err != nil {
-		return t.handleProcessError(
-			ctx, "process-input", "unknown", fmt.Errorf("Input must be a json object: %s", err),
-		)
+		return t.sendTaskFailure(TaskFailureTaskInputNotJSON{input: input})
 	}
-	executionName, _ := taskInput["_EXECUTION_NAME"].(string)
+
+	// convention: if the input contains _EXECUTION_NAME, pass it to the environment of the command
+	var executionName *string
+	if e, ok := taskInput["_EXECUTION_NAME"].(string); ok {
+		executionName = &e
+		t.logger.AddContext("execution_name", *executionName)
+	}
 
 	marshaledInput, err := json.Marshal(taskInput)
 	if err != nil {
-		return t.handleProcessError(ctx, "process-input", executionName, err)
+		return t.sendTaskFailure(TaskFailureUnknown{fmt.Errorf("JSON input re-marshalling failed. This should never happen. %s", err)})
 	}
 
 	args = append(args, string(marshaledInput))
 
-	cmd := exec.CommandContext(ctx, t.cmd, args...)
-	cmd.Env = append(os.Environ(), "_EXECUTION_NAME="+executionName)
+	t.execCmd = exec.CommandContext(ctx, t.cmd, args...)
+	if executionName != nil {
+		t.execCmd.Env = append(os.Environ(), "_EXECUTION_NAME="+*executionName)
+	}
 
 	// Write the stdout and stderr of the process to both this process' stdout and stderr
 	// and also write to a byte buffer so that we can send the result to step functions
 	stderrbuf, _ := circbuf.NewBuffer(maxTaskFailureCauseLength)
 	stdoutbuf, _ := circbuf.NewBuffer(maxTaskOutputLength)
-	cmd.Stderr = io.MultiWriter(os.Stderr, stderrbuf)
-	cmd.Stdout = io.MultiWriter(os.Stdout, stdoutbuf)
+	t.execCmd.Stderr = io.MultiWriter(os.Stderr, stderrbuf)
+	t.execCmd.Stdout = io.MultiWriter(os.Stdout, stdoutbuf)
 
-	log.InfoD("exec-command-start", logger.M{
-		"args": args, "cmd": t.cmd, "execution_name": executionName,
-	})
-	if err := cmd.Run(); err != nil {
-		return t.handleProcessError(ctx, "exec-command-err", executionName, err)
+	// forward signals to the command, handle SIGTERM
+	go t.handleSignals(ctx)
+
+	t.logger.InfoD("exec-command-start", logger.M{"args": args, "cmd": t.cmd})
+	if err := t.execCmd.Run(); err != nil {
+		stderr := strings.TrimSpace(stderrbuf.String()) // remove trailing newline
+		customErrorName := parseCustomErrorNameFromStdout(stdoutbuf.String())
+		if t.receivedSigterm {
+			if customErrorName != "" {
+				return t.sendTaskFailure(TaskFailureCustomErrorName{errorName: customErrorName, stderr: stderr})
+			}
+			return t.sendTaskFailure(TaskFailureCommandTerminated{stderr: stderr})
+		}
+		switch err := err.(type) {
+		case *os.PathError:
+			return t.sendTaskFailure(TaskFailureCommandNotFound{path: err.Path})
+		case *exec.ExitError:
+			status := err.ProcessState.Sys().(syscall.WaitStatus)
+			switch {
+			case status.Exited() && status.ExitStatus() > 0:
+				if customErrorName != "" {
+					return t.sendTaskFailure(TaskFailureCustomErrorName{errorName: customErrorName, stderr: stderr})
+				}
+				return t.sendTaskFailure(TaskFailureCommandExitedNonzero{stderr: stderr})
+			case status.Signaled() && status.Signal() == syscall.SIGKILL:
+				return t.sendTaskFailure(TaskFailureCommandKilled{stderr: stderr})
+			}
+		}
+		return t.sendTaskFailure(TaskFailureUnknown{err})
 	}
-	log.InfoD("exec-command-end", logger.M{"execution_name": executionName})
+	t.logger.Info("exec-command-end")
 
-	// AWS requires JSON output. If it isn't, then make it so.
-	output := stdoutbuf.String()
+	// AWS / states language requires JSON output
+	stdout := strings.TrimSpace(stdoutbuf.String()) // remove trailing newline
 	var out map[string]interface{}
-	if err := json.Unmarshal([]byte(output), &out); err != nil {
-		wrappedErr := fmt.Errorf("Worker must output json object to stdout: %s", err)
-		return t.handleProcessError(ctx, "process-output", executionName, wrappedErr)
+	if err := json.Unmarshal([]byte(stdout), &out); err != nil {
+		return t.sendTaskFailure(TaskFailureCommandOutputNotJSON{stdout: stdout})
 	}
-	out["_EXECUTION_NAME"] = executionName
+	if executionName != nil {
+		out["_EXECUTION_NAME"] = *executionName
+	}
 
 	marshaledOut, err := json.Marshal(out)
 	if err != nil {
-		return t.handleProcessError(ctx, "process-output", executionName, err)
+		return t.sendTaskFailure(TaskFailureUnknown{fmt.Errorf("JSON output re-marshalling failed. This should never happen. %s", err)})
 	}
 	_, err = t.sfnapi.SendTaskSuccessWithContext(ctx, &sfn.SendTaskSuccessInput{
 		Output:    aws.String(string(marshaledOut)),
 		TaskToken: &t.taskToken,
 	})
 	if err != nil {
-		log.ErrorD(
-			"process-success", logger.M{"error": err.Error(), "execution_name": executionName},
-		)
+		t.logger.ErrorD("send-task-succes-error", logger.M{"error": err.Error()})
 	}
 
 	return err
+}
+
+func (t *TaskRunner) handleSignals(ctx context.Context) {
+	sigChan := make(chan os.Signal)
+	signal.Notify(sigChan)
+	defer signal.Stop(sigChan)
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case sigReceived := <-sigChan:
+			if t.execCmd.Process == nil {
+				continue
+			}
+			pid := t.execCmd.Process.Pid
+			// SIGTERM is special. If it gets sent to sfncli, initiate a docker-stop like shutdown process:
+			// - forward the SIGTERM to the command
+			// - after a grace period (5s) send SIGKILL to the command if it's still running
+			if sigReceived == syscall.SIGTERM {
+				t.receivedSigterm = true
+				go func(pidtokill int) {
+					time.Sleep(5 * time.Second) // grace period
+					signalProcess(pidtokill, os.Signal(syscall.SIGKILL))
+				}(pid)
+			}
+			signalProcess(pid, sigReceived)
+		}
+		if t.receivedSigterm {
+			return
+		}
+	}
+}
+
+func signalProcess(pid int, signal os.Signal) {
+	proc := os.Process{Pid: pid}
+	proc.Signal(signal)
+}
+
+func parseCustomErrorNameFromStdout(stdout string) string {
+	var customError struct {
+		ErrorName string `json:"error_name"`
+	}
+	json.Unmarshal([]byte(stdout), &customError)
+	return customError.ErrorName
 }

--- a/cmd/sfncli/runner_test.go
+++ b/cmd/sfncli/runner_test.go
@@ -1,0 +1,260 @@
+package main
+
+import (
+	"context"
+	"os"
+	"path"
+	"syscall"
+	"testing"
+	"time"
+
+	"github.com/Clever/sfncli/gen-go/mocksfn"
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/sfn"
+	"github.com/golang/mock/gomock"
+	"github.com/stretchr/testify/require"
+)
+
+const mockTaskToken = "taskToken"
+
+const emptyTaskInput = "{}"
+
+var testScriptsDir = os.Getenv("GOPATH") + "/src/github.com/Clever/sfncli/cmd/sfncli/test_scripts"
+
+type sfncliErrorNameTest struct {
+	description         string
+	expectedError       TaskFailureError
+	testScript          string
+	postScriptExecution func(*TaskRunner)
+}
+
+func TestTaskFailureTaskInputNotJSON(t *testing.T) {
+	t.Parallel()
+	testCtx, testCtxCancel := context.WithCancel(context.Background())
+	defer testCtxCancel()
+	cmd := "echo"
+	cmdArgs := []string{}
+	taskInput := "notjson"
+	expectedError := TaskFailureTaskInputNotJSON{input: "notjson"}
+
+	controller := gomock.NewController(t)
+	defer controller.Finish()
+	mockSFN := mocksfn.NewMockSFNAPI(controller)
+	mockSFN.EXPECT().SendTaskFailure(&sfn.SendTaskFailureInput{
+		Cause:     aws.String(expectedError.Error()),
+		Error:     aws.String(expectedError.ErrorName()),
+		TaskToken: aws.String(mockTaskToken),
+	})
+	taskRunner := NewTaskRunner(path.Join(testScriptsDir, cmd), mockSFN, mockTaskToken)
+	err := taskRunner.Process(testCtx, cmdArgs, taskInput)
+	require.Equal(t, err, expectedError)
+
+}
+
+func TestTaskFailureCommandNotFound(t *testing.T) {
+	t.Parallel()
+	testCtx, testCtxCancel := context.WithCancel(context.Background())
+	defer testCtxCancel()
+	cmd := "doesntexist.sh"
+	cmdArgs := []string{}
+	expectedError := TaskFailureCommandNotFound{path: path.Join(testScriptsDir, cmd)}
+
+	controller := gomock.NewController(t)
+	defer controller.Finish()
+	mockSFN := mocksfn.NewMockSFNAPI(controller)
+	mockSFN.EXPECT().SendTaskFailure(&sfn.SendTaskFailureInput{
+		Cause:     aws.String(expectedError.Error()),
+		Error:     aws.String(expectedError.ErrorName()),
+		TaskToken: aws.String(mockTaskToken),
+	})
+	taskRunner := NewTaskRunner(path.Join(testScriptsDir, cmd), mockSFN, mockTaskToken)
+	err := taskRunner.Process(testCtx, cmdArgs, emptyTaskInput)
+	require.Equal(t, err, expectedError)
+}
+
+func TestTaskFailureCommandKilled(t *testing.T) {
+	t.Parallel()
+	testCtx, testCtxCancel := context.WithCancel(context.Background())
+	defer testCtxCancel()
+	cmd := "log_to_stderr_and_wait.sh"
+	cmdArgs := []string{"log this to stderr"}
+	expectedError := TaskFailureCommandKilled{stderr: cmdArgs[0]}
+
+	controller := gomock.NewController(t)
+	defer controller.Finish()
+	mockSFN := mocksfn.NewMockSFNAPI(controller)
+	mockSFN.EXPECT().SendTaskFailure(&sfn.SendTaskFailureInput{
+		Cause:     aws.String(expectedError.Error()),
+		Error:     aws.String(expectedError.ErrorName()),
+		TaskToken: aws.String(mockTaskToken),
+	})
+	taskRunner := NewTaskRunner(path.Join(testScriptsDir, cmd), mockSFN, mockTaskToken)
+	go func() {
+		time.Sleep(2 * time.Second)
+		taskRunner.execCmd.Process.Signal(syscall.SIGKILL)
+	}()
+	err := taskRunner.Process(testCtx, cmdArgs, emptyTaskInput)
+	require.Equal(t, err, expectedError)
+}
+
+func TestTaskFailureCommandExitedNonzero(t *testing.T) {
+	t.Parallel()
+	testCtx, testCtxCancel := context.WithCancel(context.Background())
+	defer testCtxCancel()
+	cmd := "stderr_stdout_exitcode.sh"
+	cmdArgs := []string{"stderr", `{"stdout":"mustbejson"}`, "10"}
+	expectedError := TaskFailureCommandExitedNonzero{stderr: "stderr"}
+
+	controller := gomock.NewController(t)
+	defer controller.Finish()
+	mockSFN := mocksfn.NewMockSFNAPI(controller)
+	mockSFN.EXPECT().SendTaskFailure(&sfn.SendTaskFailureInput{
+		Cause:     aws.String(expectedError.Error()),
+		Error:     aws.String(expectedError.ErrorName()),
+		TaskToken: aws.String(mockTaskToken),
+	})
+	taskRunner := NewTaskRunner(path.Join(testScriptsDir, cmd), mockSFN, mockTaskToken)
+	err := taskRunner.Process(testCtx, cmdArgs, emptyTaskInput)
+	require.Equal(t, err, expectedError)
+}
+
+func TestTaskFailureCustomErrorName(t *testing.T) {
+	t.Parallel()
+	testCtx, testCtxCancel := context.WithCancel(context.Background())
+	defer testCtxCancel()
+	cmd := "stderr_stdout_exitcode.sh"
+	cmdArgs := []string{"stderr", `{"error_name": "custom.error_name"}`, "10"}
+	expectedError := TaskFailureCustomErrorName{errorName: "custom.error_name", stderr: "stderr"}
+
+	controller := gomock.NewController(t)
+	defer controller.Finish()
+	mockSFN := mocksfn.NewMockSFNAPI(controller)
+	mockSFN.EXPECT().SendTaskFailure(&sfn.SendTaskFailureInput{
+		Cause:     aws.String(expectedError.Error()),
+		Error:     aws.String(expectedError.ErrorName()),
+		TaskToken: aws.String(mockTaskToken),
+	})
+	taskRunner := NewTaskRunner(path.Join(testScriptsDir, cmd), mockSFN, mockTaskToken)
+	err := taskRunner.Process(testCtx, cmdArgs, emptyTaskInput)
+	require.Equal(t, err, expectedError)
+}
+
+func TestTaskFailureCommandOutputNotJSON(t *testing.T) {
+	t.Parallel()
+	testCtx, testCtxCancel := context.WithCancel(context.Background())
+	defer testCtxCancel()
+	cmd := "stderr_stdout_exitcode.sh"
+	cmdArgs := []string{"stderr", `stdout not JSON!`, "0"}
+	expectedError := TaskFailureCommandOutputNotJSON{stdout: "stdout not JSON!"}
+
+	controller := gomock.NewController(t)
+	defer controller.Finish()
+	mockSFN := mocksfn.NewMockSFNAPI(controller)
+	mockSFN.EXPECT().SendTaskFailure(&sfn.SendTaskFailureInput{
+		Cause:     aws.String(expectedError.Error()),
+		Error:     aws.String(expectedError.ErrorName()),
+		TaskToken: aws.String(mockTaskToken),
+	})
+	taskRunner := NewTaskRunner(path.Join(testScriptsDir, cmd), mockSFN, mockTaskToken)
+	err := taskRunner.Process(testCtx, cmdArgs, emptyTaskInput)
+	require.Equal(t, err, expectedError)
+}
+
+func TestTaskFailureCommandTerminated(t *testing.T) {
+	t.Run("command handles sigterm, exits nonzero", func(t *testing.T) {
+		testCtx, testCtxCancel := context.WithCancel(context.Background())
+		defer testCtxCancel()
+		cmd := "stderr_stdout_exitcode_onsigterm.sh"
+		cmdArgs := []string{"stderr", "", "1"}
+		expectedError := TaskFailureCommandTerminated{stderr: "stderr"}
+
+		controller := gomock.NewController(t)
+		defer controller.Finish()
+		mockSFN := mocksfn.NewMockSFNAPI(controller)
+		mockSFN.EXPECT().SendTaskFailure(&sfn.SendTaskFailureInput{
+			Cause:     aws.String(expectedError.Error()),
+			Error:     aws.String(expectedError.ErrorName()),
+			TaskToken: aws.String(mockTaskToken),
+		})
+		taskRunner := NewTaskRunner(path.Join(testScriptsDir, cmd), mockSFN, mockTaskToken)
+		go func() {
+			time.Sleep(1 * time.Second)
+			process, _ := os.FindProcess(os.Getpid())
+			process.Signal(syscall.SIGTERM)
+		}()
+		err := taskRunner.Process(testCtx, cmdArgs, emptyTaskInput)
+		require.Equal(t, err, expectedError)
+	})
+
+	t.Run("command handles sigterm, exits nonzero with custom error code", func(t *testing.T) {
+		testCtx, testCtxCancel := context.WithCancel(context.Background())
+		defer testCtxCancel()
+		cmd := "stderr_stdout_exitcode_onsigterm.sh"
+		cmdArgs := []string{"stderr", `{"error_name": "custom.error_name"}`, "1"}
+		expectedError := TaskFailureCustomErrorName{errorName: "custom.error_name", stderr: "stderr"}
+
+		controller := gomock.NewController(t)
+		defer controller.Finish()
+		mockSFN := mocksfn.NewMockSFNAPI(controller)
+		mockSFN.EXPECT().SendTaskFailure(&sfn.SendTaskFailureInput{
+			Cause:     aws.String(expectedError.Error()),
+			Error:     aws.String(expectedError.ErrorName()),
+			TaskToken: aws.String(mockTaskToken),
+		})
+		taskRunner := NewTaskRunner(path.Join(testScriptsDir, cmd), mockSFN, mockTaskToken)
+		go func() {
+			time.Sleep(1 * time.Second)
+			process, _ := os.FindProcess(os.Getpid())
+			process.Signal(syscall.SIGTERM)
+		}()
+		err := taskRunner.Process(testCtx, cmdArgs, emptyTaskInput)
+		require.Equal(t, err, expectedError)
+	})
+
+	t.Run("command does not handle sigterm", func(t *testing.T) {
+		testCtx, testCtxCancel := context.WithCancel(context.Background())
+		defer testCtxCancel()
+		cmd := "stderr_stdout_loopforever.sh"
+		cmdArgs := []string{"stderr", ""}
+		expectedError := TaskFailureCommandTerminated{stderr: "stderr"}
+
+		controller := gomock.NewController(t)
+		defer controller.Finish()
+		mockSFN := mocksfn.NewMockSFNAPI(controller)
+		mockSFN.EXPECT().SendTaskFailure(&sfn.SendTaskFailureInput{
+			Cause:     aws.String(expectedError.Error()),
+			Error:     aws.String(expectedError.ErrorName()),
+			TaskToken: aws.String(mockTaskToken),
+		})
+		taskRunner := NewTaskRunner(path.Join(testScriptsDir, cmd), mockSFN, mockTaskToken)
+		go func() {
+			time.Sleep(1 * time.Second)
+			process, _ := os.FindProcess(os.Getpid())
+			process.Signal(syscall.SIGTERM)
+		}()
+		err := taskRunner.Process(testCtx, cmdArgs, emptyTaskInput)
+		require.Equal(t, err, expectedError)
+	})
+}
+
+func TestTaskSuccessSignalForwarded(t *testing.T) {
+	testCtx, testCtxCancel := context.WithCancel(context.Background())
+	defer testCtxCancel()
+	cmd := "signal_echo.sh"
+	cmdArgs := []string{}
+
+	controller := gomock.NewController(t)
+	mockSFN := mocksfn.NewMockSFNAPI(controller)
+	mockSFN.EXPECT().SendTaskSuccessWithContext(gomock.Any(), &sfn.SendTaskSuccessInput{
+		Output:    aws.String(`{"signal":"1"}`),
+		TaskToken: aws.String(mockTaskToken),
+	})
+	defer controller.Finish()
+	taskRunner := NewTaskRunner(path.Join(testScriptsDir, cmd), mockSFN, mockTaskToken)
+	go func() {
+		time.Sleep(1 * time.Second)
+		process, _ := os.FindProcess(os.Getpid())
+		process.Signal(syscall.SIGHUP)
+	}()
+	require.Nil(t, taskRunner.Process(testCtx, cmdArgs, emptyTaskInput))
+}

--- a/cmd/sfncli/runner_test.go
+++ b/cmd/sfncli/runner_test.go
@@ -19,7 +19,7 @@ const mockTaskToken = "taskToken"
 
 const emptyTaskInput = "{}"
 
-var testScriptsDir = os.Getenv("GOPATH") + "/src/github.com/Clever/sfncli/cmd/sfncli/test_scripts"
+var testScriptsDir = "./test_scripts"
 
 func TestTaskFailureTaskInputNotJSON(t *testing.T) {
 	t.Parallel()

--- a/cmd/sfncli/runner_test.go
+++ b/cmd/sfncli/runner_test.go
@@ -220,6 +220,8 @@ func TestTaskFailureCommandTerminated(t *testing.T) {
 			TaskToken: aws.String(mockTaskToken),
 		})
 		taskRunner := NewTaskRunner(path.Join(testScriptsDir, cmd), mockSFN, mockTaskToken)
+		// lower the grace period so this test doesn't take forever
+		taskRunner.sigtermGracePeriod = 5 * time.Second
 		go func() {
 			time.Sleep(1 * time.Second)
 			process, _ := os.FindProcess(os.Getpid())

--- a/cmd/sfncli/sfncli.go
+++ b/cmd/sfncli/sfncli.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"os"
 	"os/signal"
+	"syscall"
 	"time"
 
 	"github.com/aws/aws-sdk-go/aws"
@@ -64,7 +65,7 @@ func main() {
 
 	mainCtx, mainCtxCancel := context.WithCancel(context.Background())
 	c := make(chan os.Signal, 1)
-	signal.Notify(c, os.Interrupt)
+	signal.Notify(c, os.Interrupt, os.Signal(syscall.SIGTERM))
 	go func() {
 		for _ = range c {
 			// sig is a ^C, handle it

--- a/cmd/sfncli/test_scripts/log_to_stderr_and_wait.sh
+++ b/cmd/sfncli/test_scripts/log_to_stderr_and_wait.sh
@@ -1,0 +1,7 @@
+#!/usr/bin/env bash
+
+echo $1 1>&2
+
+while true; do
+    sleep 1
+done    

--- a/cmd/sfncli/test_scripts/signal_echo.sh
+++ b/cmd/sfncli/test_scripts/signal_echo.sh
@@ -1,0 +1,24 @@
+#!/usr/bin/env bash
+
+exitCode=0
+if [ "$#" -eq 2 ]; then
+    exitCode=$1
+fi
+
+trap_with_arg() {
+    func="$1" ; shift
+    for sig ; do
+        trap "$func $sig" "$sig"
+    done
+}
+
+func_trap() {
+    echo "{\"signal\": \"$1\"}"
+    exit $exitCode
+}
+
+trap_with_arg func_trap 1 2 3 4 5 6 7 8 9 10 11 12 13 14 15 16 17 18 19 20 21 22 23 24 25 26 27 28 29 30 31 32 33 34 35 36 37 38 39 40 41 42 43 44 45 46 47 48 49 50 51 52 53 54 55 56 57 58 59 60 61 62 63 64
+
+while true; do
+    sleep 1
+done    

--- a/cmd/sfncli/test_scripts/stderr_stdout_exitcode.sh
+++ b/cmd/sfncli/test_scripts/stderr_stdout_exitcode.sh
@@ -1,0 +1,10 @@
+#!/usr/bin/env bash
+
+# write something to stderr
+echo $1 1>&2
+
+# write stuff to stdout
+echo $2
+
+# exit
+exit $3

--- a/cmd/sfncli/test_scripts/stderr_stdout_exitcode_onsigterm.sh
+++ b/cmd/sfncli/test_scripts/stderr_stdout_exitcode_onsigterm.sh
@@ -1,0 +1,21 @@
+#!/usr/bin/env bash
+
+stderr=$1
+stdout=$2
+exitcode=$3
+function on_sigterm {
+    # write something to stderr
+    echo $stderr 1>&2
+
+    # write stuff to stdout
+    echo $stdout
+
+    # exit
+    exit $exitcode
+}
+
+trap on_sigterm SIGTERM
+
+while true; do
+    sleep 1
+done

--- a/cmd/sfncli/test_scripts/stderr_stdout_loopforever.sh
+++ b/cmd/sfncli/test_scripts/stderr_stdout_loopforever.sh
@@ -1,0 +1,19 @@
+#!/usr/bin/env bash
+
+# write something to stderr
+echo $1 1>&2
+
+# write stuff to stdout
+echo $2
+
+function on_sigterm {
+    while true; do
+        sleep 1
+    done
+}
+
+trap on_sigterm SIGTERM
+
+while true; do
+    sleep 1
+done

--- a/cmd/sfncli/test_scripts/stdout_parsing.sh
+++ b/cmd/sfncli/test_scripts/stdout_parsing.sh
@@ -1,0 +1,8 @@
+#!/usr/bin/env bash
+
+echo "some"
+echo "other"
+echo "stuff"
+echo "even some stderr" 2>&1
+echo "and now for the main event:"
+echo "{\"task\": \"output\"}"

--- a/glide.lock
+++ b/glide.lock
@@ -1,5 +1,5 @@
-hash: b2fd22e0bbd24cc6fc5063d157e7e41d657ce6c3b6f2cd92b038225201ccd47b
-updated: 2017-10-03T21:10:35.661381589Z
+hash: 090245037cf79bdd45c82b01ffa97f8f89dc852acc9354f4e88f60caf9238b86
+updated: 2017-10-04T22:59:11.536413441Z
 imports:
 - name: github.com/armon/circbuf
   version: bbbad097214e2918d8543d5201d12bfd7bca254d
@@ -34,7 +34,11 @@ imports:
   - service/sfn/sfniface
   - service/sts
 - name: github.com/go-ini/ini
-  version: 20b96f641a5ea98f2f8619ff4f3e061cff4833bd
+  version: c787282c39ac1fc618827141a1f762240def08a3
+- name: github.com/golang/mock
+  version: 13f360950a79f5864a972c786a10a50e44b69541
+  subpackages:
+  - gomock
 - name: github.com/jmespath/go-jmespath
   version: bd40a432e4c76585ef6b72d3fd96fb9b6dc7b68d
 - name: github.com/xeipuuv/gojsonpointer
@@ -51,5 +55,16 @@ imports:
 - name: gopkg.in/yaml.v2
   version: eb3733d160e74a9c7e442f435eb3bea458e1d19f
 testImports:
-- name: github.com/golang/mock
-  version: 13f360950a79f5864a972c786a10a50e44b69541
+- name: github.com/davecgh/go-spew
+  version: 6d212800a42e8ab5c146b8ace3490ee17e5225f9
+  subpackages:
+  - spew
+- name: github.com/pmezard/go-difflib
+  version: d8ed2627bdf02c080bf22230dbb337003b7aba2d
+  subpackages:
+  - difflib
+- name: github.com/stretchr/testify
+  version: 69483b4bd14f5845b5a1e55bca19e954e827f1d0
+  subpackages:
+  - assert
+  - require

--- a/glide.lock
+++ b/glide.lock
@@ -1,10 +1,10 @@
-hash: ae45a382a18c2b323883b4471bdd4d3307b18be7d06d1a9b811be3739284ff54
-updated: 2017-09-19T23:03:15.467189207Z
+hash: b2fd22e0bbd24cc6fc5063d157e7e41d657ce6c3b6f2cd92b038225201ccd47b
+updated: 2017-10-03T21:10:35.661381589Z
 imports:
 - name: github.com/armon/circbuf
   version: bbbad097214e2918d8543d5201d12bfd7bca254d
 - name: github.com/aws/aws-sdk-go
-  version: 9924c83c280264fb32f34cc5095204c451bedf0c
+  version: 0bac5578f9a18b467487ee2dda67fedb328e9452
   subpackages:
   - aws
   - aws/awserr
@@ -34,7 +34,7 @@ imports:
   - service/sfn/sfniface
   - service/sts
 - name: github.com/go-ini/ini
-  version: c787282c39ac1fc618827141a1f762240def08a3
+  version: 20b96f641a5ea98f2f8619ff4f3e061cff4833bd
 - name: github.com/jmespath/go-jmespath
   version: bd40a432e4c76585ef6b72d3fd96fb9b6dc7b68d
 - name: github.com/xeipuuv/gojsonpointer
@@ -44,10 +44,12 @@ imports:
 - name: github.com/xeipuuv/gojsonschema
   version: 3f523f4c14b6e925da10475eb0447c2f28614aac
 - name: gopkg.in/Clever/kayvee-go.v6
-  version: e6f953eac5b9d8e41dff6587e0ae6d58b50da5c5
+  version: e1e6fd8184162847c1123645e7058347a2fd3959
   subpackages:
   - logger
   - router
 - name: gopkg.in/yaml.v2
   version: eb3733d160e74a9c7e442f435eb3bea458e1d19f
-testImports: []
+testImports:
+- name: github.com/golang/mock
+  version: 13f360950a79f5864a972c786a10a50e44b69541

--- a/glide.yaml
+++ b/glide.yaml
@@ -7,4 +7,5 @@ import:
 - package: github.com/armon/circbuf
 testImport:
 - package: github.com/golang/mock
-  version: ^1.0.0
+- package: github.com/stretchr/testify
+  version: ^1.1.4

--- a/glide.yaml
+++ b/glide.yaml
@@ -1,15 +1,10 @@
 package: github.com/Clever/sfncli
 import:
 - package: github.com/aws/aws-sdk-go
-  version: ^1.10.46
-  subpackages:
-  - aws
-  - aws/awserr
-  - aws/session
-  - service/sfn
-  - service/sfn/sfniface
+  version: ^1.12.4
 - package: gopkg.in/Clever/kayvee-go.v6
   version: ^6.7.3
-  subpackages:
-  - logger
 - package: github.com/armon/circbuf
+testImport:
+- package: github.com/golang/mock
+  version: ^1.0.0


### PR DESCRIPTION
https://clever.atlassian.net/browse/INFRA-2542

1. Adds the following built-in error names:

- `sfncli.TaskInputNotJSON`: input to the task was not JSON
 - `sfncli.CommandNotFound`: the command passed to `sfncli` was not found
 - `sfncli.CommandKilled`: the command process received SIGKILL
 - `sfncli.CommandExitedNonzero`: the command process exited with a nonzero exit code
 - `sfncli.TaskOutputNotJSON`: the task output (last line of command's stdout) was not JSON
 - `sfncli.CommandTerminated`: `sfncli` received SIGTERM
 - `sfncli.Unknown`: unexpected / unclassified errors

In practice the most common one will be `sfncli.CommandTerminated`, which will happen any time we deploy a new worker and ECS / docker stops containers via SIGTERM.

2. JSON output of a task now taken from the last non-empty line of stdout (instead of all of looking at the entirety of stdout)

3. Lets workers produce their own error names by including an `error_name` key in the output JSON

