### PR TITLE
Treat empty worker output the same as empty object '{}'

### DIFF
--- a/cmd/sfncli/runner.go
+++ b/cmd/sfncli/runner.go
@@ -121,7 +121,9 @@ func (t *TaskRunner) Process(ctx context.Context, args []string, input string) e
 	// AWS / states language requires JSON output
 	taskOutput := taskOutputFromStdout(stdoutbuf.String())
 	var taskOutputMap map[string]interface{}
-	if err := json.Unmarshal([]byte(taskOutput), &taskOutputMap); err != nil {
+	if len(taskOutput) == 0 { // Treat "" output like {}.  Makes worker implementions easier.
+		taskOutputMap = map[string]interface{}{}
+	} else if err := json.Unmarshal([]byte(taskOutput), &taskOutputMap); err != nil {
 		return t.sendTaskFailure(TaskFailureTaskOutputNotJSON{output: taskOutput})
 	}
 	if executionName != nil {

--- a/cmd/sfncli/runner_test.go
+++ b/cmd/sfncli/runner_test.go
@@ -44,6 +44,27 @@ func TestTaskFailureTaskInputNotJSON(t *testing.T) {
 
 }
 
+func TestTaskOutputEmptyStringAsJSON(t *testing.T) {
+	t.Parallel()
+	testCtx, testCtxCancel := context.WithCancel(context.Background())
+	defer testCtxCancel()
+	cmd := "stdout_empty_output.sh"
+	cmdArgs := []string{}
+	taskInput := "{}"
+
+	controller := gomock.NewController(t)
+	defer controller.Finish()
+	mockSFN := mocksfn.NewMockSFNAPI(controller)
+	mockSFN.EXPECT().SendTaskSuccessWithContext(gomock.Any(), &sfn.SendTaskSuccessInput{
+		TaskToken: aws.String(mockTaskToken),
+		Output:    aws.String("{}"),
+	})
+	taskRunner := NewTaskRunner(path.Join(testScriptsDir, cmd), mockSFN, mockTaskToken)
+	err := taskRunner.Process(testCtx, cmdArgs, taskInput)
+	require.NoError(t, err)
+
+}
+
 func TestTaskFailureCommandNotFound(t *testing.T) {
 	t.Parallel()
 	testCtx, testCtxCancel := context.WithCancel(context.Background())

--- a/cmd/sfncli/test_scripts/stdout_empty_output.sh
+++ b/cmd/sfncli/test_scripts/stdout_empty_output.sh
@@ -1,0 +1,1 @@
+#!/usr/bin/env bash


### PR DESCRIPTION
cc @mohit 