### PR TITLE
catch context canceled error

### DIFF
--- a/cmd/sfncli/sfncli.go
+++ b/cmd/sfncli/sfncli.go
@@ -195,6 +195,10 @@ func taskHeartbeat(ctx context.Context, sfnapi sfniface.SFNAPI, token string) er
 						return err
 					}
 				}
+				if err == context.Canceled {
+					// context was canceled while sending heartbeat
+					return nil
+				}
 				log.ErrorD("heartbeat-error-unknown", logger.M{"error": err.Error()}) // keep trying on unknown errors
 			}
 		}


### PR DESCRIPTION
sometimes the context finishes while we're sending a heartbeat: https://production--haproxy-logs.int.clever.com/_plugin/kibana/#/discover?_g=(refreshInterval:(display:Off,pause:!f,section:0,value:0),time:(from:now-1h,mode:quick,to:now))&_a=(columns:!(rawlog),index:%5Blogs-%5DYYYY-MM-DD,interval:auto,query:(query_string:(analyze_wildcard:!t,lowercase_expanded_terms:!f,query:'title:heartbeat-error-unknown')),sort:!(timestamp,desc))