### PR TITLE
report active percent instead of active time

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,8 +8,6 @@
 .\#*
 
 vendor/
-build/
 bin/
 release/
-mockgen
-gen-go/mocksfn
+gen-go/

--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -90,6 +90,6 @@
 [solve-meta]
   analyzer-name = "dep"
   analyzer-version = 1
-  inputs-digest = "f7e15934345d39d2993491cf0686838e01667afa5719b7952a9d4a741b60aa4b"
+  inputs-digest = "f1a51c03f2c503d5317c403a87d344643302de14283a27ae5fc3bd3dc8279c37"
   solver-name = "gps-cdcl"
   solver-version = 1

--- a/cmd/sfncli/cloudwatchreporter.go
+++ b/cmd/sfncli/cloudwatchreporter.go
@@ -2,7 +2,7 @@ package main
 
 import (
 	"context"
-	"sync/atomic"
+	"sync"
 	"time"
 
 	"github.com/aws/aws-sdk-go/aws"
@@ -11,24 +11,42 @@ import (
 	"gopkg.in/Clever/kayvee-go.v6/logger"
 )
 
+const metricNameActivityActivePercent = "ActivityActivePercent"
+const namespaceStatesCustom = "StatesCustom"
+
 // CloudWatchReporter reports useful metrics about the activity.
 type CloudWatchReporter struct {
 	cwapi       cloudwatchiface.CloudWatchAPI
 	activityArn string
-	idleTime    int64
+
+	// state to keep track of active percent
+	// the mutex is here to control access by two goroutines, e.g.
+	// 1. the goroutine for `ReportActivePercent`
+	// 2. the goroutine that calls ActiveUntilContextDone
+	mu                    sync.Mutex
+	activeState           bool
+	activeTime            time.Duration
+	lastReportingTime     time.Time
+	lastActiveStateChange time.Time
 }
 
 func NewCloudWatchReporter(cwapi cloudwatchiface.CloudWatchAPI, activityArn string) *CloudWatchReporter {
+	now := time.Now()
 	c := &CloudWatchReporter{
 		cwapi:       cwapi,
 		activityArn: activityArn,
+
+		activeState:           false,
+		activeTime:            time.Duration(0),
+		lastReportingTime:     now,
+		lastActiveStateChange: now,
 	}
 	return c
 }
 
-// ReportIdleTime reports time spent idle to cloudwatch as a counter.
+// ReportActivePercent sets up a loop that will report active percent to cloudwatch on an interval.
 // It stops when the context is canceled.
-func (cwr *CloudWatchReporter) ReportIdleTime(ctx context.Context, interval time.Duration) {
+func (c *CloudWatchReporter) ReportActivePercent(ctx context.Context, interval time.Duration) {
 	ticker := time.NewTicker(interval)
 	defer ticker.Stop()
 	for ctx.Err() == nil {
@@ -36,30 +54,72 @@ func (cwr *CloudWatchReporter) ReportIdleTime(ctx context.Context, interval time
 		case <-ctx.Done():
 			break
 		case <-ticker.C:
-			val := atomic.SwapInt64(&cwr.idleTime, 0) // reset counter to zero
-			log.InfoD("reportidletime", logger.M{"seconds": time.Duration(val) / time.Second})
-			if _, err := cwr.cwapi.PutMetricDataWithContext(ctx, &cloudwatch.PutMetricDataInput{
-				MetricData: []*cloudwatch.MetricDatum{{
-					Dimensions: []*cloudwatch.Dimension{{
-						Name:  aws.String("ActivityArn"),
-						Value: aws.String(cwr.activityArn),
-					}},
-					MetricName: aws.String("ActivityIdleTimeSeconds"),
-					Unit:       aws.String(cloudwatch.StandardUnitSeconds),
-					Value:      aws.Float64(float64(time.Duration(val) / time.Second)),
-				}},
-				Namespace: aws.String("StatesCustom"),
-			}); err != nil && err != context.Canceled {
-				log.ErrorD("reportidletime-error", logger.M{"error": err.Error()})
-				// add back value to account for failure to record it in cloudwatch
-				atomic.AddInt64(&cwr.idleTime, val)
-			}
+			c.report()
 		}
 	}
-	log.Info("reportidletime-stop")
 }
 
-// CountIdleTime records time spent idle.
-func (cwr *CloudWatchReporter) CountIdleTime(idle time.Duration) {
-	atomic.AddInt64(&cwr.idleTime, int64(idle))
+// ActiveUntilContextDone sets active state to true, and sets it false when the context is done.
+func (c *CloudWatchReporter) ActiveUntilContextDone(ctx context.Context) {
+	c.setActiveState(true)
+	<-ctx.Done()
+	c.setActiveState(false)
+}
+
+// setActiveState sets whether the activity is currently working on a task or not.
+func (c *CloudWatchReporter) setActiveState(active bool) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	if active == c.activeState {
+		return
+	}
+	now := time.Now()
+	// going from active to inactive, so record incremental active time
+	if c.activeState {
+		c.activeTime += now.Sub(maxTime(c.lastReportingTime, c.lastActiveStateChange))
+	}
+	c.activeState = active
+	c.lastActiveStateChange = now
+}
+
+// maxTime returns the maximum between two times
+func maxTime(a, b time.Time) time.Time {
+	if a.After(b) {
+		return a
+	}
+	return b
+}
+
+// report computes and sends the active time metric to cloudwatch, resetting state related to tracking active time.
+func (c *CloudWatchReporter) report() {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	now := time.Now()
+	// going from active to inactive, so record incremental active time
+	if c.activeState {
+		c.activeTime += now.Sub(maxTime(c.lastReportingTime, c.lastActiveStateChange))
+	}
+	activePercent := 100.0 * float64(c.activeTime) / float64(now.Sub(c.lastReportingTime))
+	c.lastReportingTime = now
+	c.activeTime = time.Duration(0)
+	// fire and forget the metric
+	go c.putMetricData(activePercent)
+}
+
+func (c *CloudWatchReporter) putMetricData(activePercent float64) {
+	log.InfoD("put-metric-data", logger.M{"activity-arn": c.activityArn, "metric-name": metricNameActivityActivePercent, "value": activePercent})
+	if _, err := c.cwapi.PutMetricData(&cloudwatch.PutMetricDataInput{
+		MetricData: []*cloudwatch.MetricDatum{{
+			Dimensions: []*cloudwatch.Dimension{{
+				Name:  aws.String("ActivityArn"),
+				Value: aws.String(c.activityArn),
+			}},
+			MetricName: aws.String(metricNameActivityActivePercent),
+			Unit:       aws.String(cloudwatch.StandardUnitPercent),
+			Value:      aws.Float64(activePercent),
+		}},
+		Namespace: aws.String(namespaceStatesCustom),
+	}); err != nil {
+		log.ErrorD("put-metric-data", logger.M{"error": err.Error()})
+	}
 }

--- a/cmd/sfncli/cloudwatchreporter_test.go
+++ b/cmd/sfncli/cloudwatchreporter_test.go
@@ -1,0 +1,127 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"math"
+	"reflect"
+	"testing"
+	"time"
+
+	"github.com/Clever/sfncli/gen-go/mockcloudwatch"
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/cloudwatch"
+	"github.com/golang/mock/gomock"
+)
+
+const mockActivityArn = "mockActivityArn"
+
+func TestCloudWatchReporterReportsActiveZero(t *testing.T) {
+	testCtx, testCtxCancel := context.WithCancel(context.Background())
+	defer testCtxCancel()
+	controller := gomock.NewController(t)
+	defer controller.Finish()
+	mockCW := mockcloudwatch.NewMockCloudWatchAPI(controller)
+	cwr := NewCloudWatchReporter(mockCW, mockActivityArn)
+	go cwr.ReportActivePercent(testCtx, 100*time.Millisecond)
+	mockCW.EXPECT().PutMetricData(&cloudwatch.PutMetricDataInput{
+		MetricData: []*cloudwatch.MetricDatum{{
+			Dimensions: []*cloudwatch.Dimension{{
+				Name:  aws.String("ActivityArn"),
+				Value: aws.String(mockActivityArn),
+			}},
+			MetricName: aws.String(metricNameActivityActivePercent),
+			Unit:       aws.String(cloudwatch.StandardUnitPercent),
+			Value:      aws.Float64(0.0),
+		}},
+		Namespace: aws.String(namespaceStatesCustom),
+	})
+	time.Sleep(100*time.Millisecond + 10*time.Millisecond)
+}
+
+func TestCloudWatchReporterReportsActiveFiftyPercent(t *testing.T) {
+	testCtx, testCtxCancel := context.WithCancel(context.Background())
+	defer testCtxCancel()
+	controller := gomock.NewController(t)
+	defer controller.Finish()
+	mockCW := mockcloudwatch.NewMockCloudWatchAPI(controller)
+	mockCW.EXPECT().PutMetricData(fuzzy(&cloudwatch.PutMetricDataInput{
+		MetricData: []*cloudwatch.MetricDatum{{
+			Dimensions: []*cloudwatch.Dimension{{
+				Name:  aws.String("ActivityArn"),
+				Value: aws.String(mockActivityArn),
+			}},
+			MetricName: aws.String(metricNameActivityActivePercent),
+			Unit:       aws.String(cloudwatch.StandardUnitPercent),
+			Value:      aws.Float64(50.0),
+		}},
+		Namespace: aws.String(namespaceStatesCustom),
+	})).Times(2)
+	cwr := NewCloudWatchReporter(mockCW, mockActivityArn)
+	go cwr.ReportActivePercent(testCtx, 1*time.Second)
+	go func() {
+		// active for 500 ms in first second and second second
+		time.Sleep(500 * time.Millisecond)
+		cwr.setActiveState(true)
+		time.Sleep(1 * time.Second)
+		cwr.setActiveState(false)
+	}()
+	// check after 2 seconds, should be 50% active on both intervals
+	time.Sleep(2*time.Second + 100*time.Millisecond)
+}
+
+func TestCloudWatchReporterReportsActiveHundredPercent(t *testing.T) {
+	testCtx, testCtxCancel := context.WithCancel(context.Background())
+	defer testCtxCancel()
+	controller := gomock.NewController(t)
+	defer controller.Finish()
+	mockCW := mockcloudwatch.NewMockCloudWatchAPI(controller)
+	mockCW.EXPECT().PutMetricData(fuzzy(&cloudwatch.PutMetricDataInput{
+		MetricData: []*cloudwatch.MetricDatum{{
+			Dimensions: []*cloudwatch.Dimension{{
+				Name:  aws.String("ActivityArn"),
+				Value: aws.String(mockActivityArn),
+			}},
+			MetricName: aws.String(metricNameActivityActivePercent),
+			Unit:       aws.String(cloudwatch.StandardUnitPercent),
+			Value:      aws.Float64(100.0),
+		}},
+		Namespace: aws.String(namespaceStatesCustom),
+	})).Times(2)
+	cwr := NewCloudWatchReporter(mockCW, mockActivityArn)
+	go cwr.ReportActivePercent(testCtx, 1*time.Second)
+	go cwr.ActiveUntilContextDone(testCtx)
+	time.Sleep(2*time.Second + 100*time.Millisecond)
+}
+
+// fuzzyMatcher is a gomock.Matcher that does a fuzzy match on cloudwatch putmetricdata values
+type fuzzyMatcher struct {
+	expected *cloudwatch.PutMetricDataInput
+}
+
+func fuzzy(expected *cloudwatch.PutMetricDataInput) gomock.Matcher {
+	return fuzzyMatcher{expected}
+}
+
+func (f fuzzyMatcher) Matches(x interface{}) bool {
+	got, ok := x.(*cloudwatch.PutMetricDataInput)
+	if !ok {
+		return false
+	}
+	epsilon := 2.00 // within 2 percent is fine
+	if len(f.expected.MetricData) != len(got.MetricData) {
+		return reflect.DeepEqual(f.expected, got)
+	}
+	for i, md := range f.expected.MetricData {
+		if math.Abs(aws.Float64Value(md.Value)-aws.Float64Value(got.MetricData[i].Value)) > epsilon {
+			return false
+		}
+		// so that deepequal succeeds, make values match exactly if they're within epsilon
+		f.expected.MetricData[i].Value = got.MetricData[i].Value
+	}
+	return reflect.DeepEqual(f.expected, x)
+}
+
+func (f fuzzyMatcher) String() string {
+	return fmt.Sprintf("is equal to %v", f.expected)
+}


### PR DESCRIPTION
Currently sfncli reports active time as a cloudwatch metric. We've refined this into an estimate of percent of time spent active in the sfx dashboard, and it's been useful for determining which workers to scale up and down: https://app.signalfx.com/#/dashboard/DL8uwWYAcAA?variables%5B%5D=namespace%3Dworkflow_namespace:production&variables%5B%5D=team%3Dteam:&variables%5B%5D=resource%3Dresource:%5B%22mp*%22%5D&startTime=-8h&endTime=Now (see ActivityIdlePercent--if it's consistently low, we can scale up, if it's high, we can scale down)

This PR changes sfncli to directly report a cloudwatch metric that is percent of time spent active. This would let us:
1) remove sfx transformations to approximate this from time spent active
2) (more importantly) unblock autoscaling, since autoscaling requires an un-altered cloudwatch metric that we can place thresholds on

Things I'd like to highlight for review:
- the code itself... I added tests since recording active percent is tricky. If the code is hard to understand/follow/etc., I want to fix that
- the name of the cloudwatch metric, and (in the near future) the name of the autoscaling metric we [expose in launch.yml](https://github.com/Clever/powerschool/blob/master/launch/powerschool.yml#L26) :
  - currently: `ActivityActivePercent` + `active-percent`(?). Pros: a worker being active vs. inactive I think is easy to understand. Cons: active + activity naming overlap might be confusing.
  - considered: `ActivityUtilization` + `utilization`(?). Pros: metric mirrors CPU / memory utilization in a lot of ways, so calling it "ActivityUtilization" might make it more recognizable?
  - other names?