### PR TITLE
send task heartbeat immediately after getting task

### DIFF
--- a/cmd/sfncli/sfncli.go
+++ b/cmd/sfncli/sfncli.go
@@ -205,7 +205,7 @@ func taskHeartbeatLoop(ctx context.Context, sfnapi sfniface.SFNAPI, token string
 	if err := sendTaskHeartbeat(ctx, sfnapi, token); err != nil {
 		return err
 	}
-	heartbeat := time.NewTicker(20 * time.Second)
+	heartbeat := time.NewTicker(15 * time.Second)
 	defer heartbeat.Stop()
 	for {
 		select {


### PR DESCRIPTION
We're seeing a 4-5 second delay between amazon recording an task assigned to a worker and the worker receiving it. The fact that we wait 20 seconds to send the first heartbeat plus the fact we have a 30 second heartbeat timeout means that we risk hitting the heartbeat timeout.

This PR changes it so that we send a heartbeat immediately upon receiving a task.

Go doesn't make it easy to create a timer with an immediate first tick, so I had to add a second heartbeat-related function