### PR TITLE
record wait time as active time

### DIFF
--- a/cmd/sfncli/cloudwatchreporter.go
+++ b/cmd/sfncli/cloudwatchreporter.go
@@ -61,13 +61,13 @@ func (c *CloudWatchReporter) ReportActivePercent(ctx context.Context, interval t
 
 // ActiveUntilContextDone sets active state to true, and sets it false when the context is done.
 func (c *CloudWatchReporter) ActiveUntilContextDone(ctx context.Context) {
-	c.setActiveState(true)
+	c.SetActiveState(true)
 	<-ctx.Done()
-	c.setActiveState(false)
+	c.SetActiveState(false)
 }
 
-// setActiveState sets whether the activity is currently working on a task or not.
-func (c *CloudWatchReporter) setActiveState(active bool) {
+// SetActiveState sets whether the activity is currently working on a task or not.
+func (c *CloudWatchReporter) SetActiveState(active bool) {
 	c.mu.Lock()
 	defer c.mu.Unlock()
 	if active == c.activeState {

--- a/cmd/sfncli/cloudwatchreporter_test.go
+++ b/cmd/sfncli/cloudwatchreporter_test.go
@@ -62,9 +62,9 @@ func TestCloudWatchReporterReportsActiveFiftyPercent(t *testing.T) {
 	go func() {
 		// active for 500 ms in first second and second second
 		time.Sleep(500 * time.Millisecond)
-		cwr.setActiveState(true)
+		cwr.SetActiveState(true)
 		time.Sleep(1 * time.Second)
-		cwr.setActiveState(false)
+		cwr.SetActiveState(false)
 	}()
 	// check after 2 seconds, should be 50% active on both intervals
 	time.Sleep(2*time.Second + 100*time.Millisecond)

--- a/cmd/sfncli/sfncli.go
+++ b/cmd/sfncli/sfncli.go
@@ -116,7 +116,10 @@ func main() {
 	// getactivitytask claims to initiate a polling loop, but it seems to return every few minutes with
 	// a nil error and empty output. So wrap it in a polling loop of our own
 	for mainCtx.Err() == nil {
-		if err := limiter.Wait(mainCtx); err != nil {
+		cw.SetActiveState(true)
+		err := limiter.Wait(mainCtx)
+		cw.SetActiveState(false)
+		if err != nil {
 			continue
 		}
 		select {


### PR DESCRIPTION
right now if a worker takes less than a second to process a task, the `ActivePercent` metric tops out below 100%. This is because we rate limit calls to `GetActivityTask` to one per second, and we don't consider the time spent waiting to stay within this rate limit as "active" time.

This PR changes the metric to record time waiting to stay within this rate limit as active time.
