### PR TITLE
INFRA-2875 — Made sfncli download more robust

### DIFF
--- a/make/sfncli.mk
+++ b/make/sfncli.mk
@@ -1,6 +1,6 @@
 # This is the default sfncli Makefile.
 # Please do not alter this file directly.
-SFNCLI_MK_VERSION := 0.1.0
+SFNCLI_MK_VERSION := 0.1.1
 SHELL := /bin/bash
 SYSTEM := $(shell uname -a | cut -d" " -f1 | tr '[:upper:]' '[:lower:]')
 SFNCLI_INSTALLED := $(shell [[ -e "bin/sfncli" ]] && bin/sfncli --version)
@@ -21,8 +21,15 @@ bin/sfncli: ensure-sfncli-version-set ensure-curl-installed
 	@mkdir -p bin
 	$(eval SFNCLI_VERSION := $(if $(filter latest,$(SFNCLI_VERSION)),$(SFNCLI_LATEST),$(SFNCLI_VERSION)))
 	@echo "Checking for sfncli updates..."
-	@echo "Using sfncli version $(SFNCLI_VERSION)"
-	@[[ "$(SFNCLI_VERSION)" != "$(SFNCLI_INSTALLED)" ]] && echo "Updating sfncli..." && curl -o bin/sfncli -sL https://github.com/Clever/sfncli/releases/download/$(SFNCLI_VERSION)/sfncli-$(SFNCLI_VERSION)-$(SYSTEM)-amd64 && chmod +x bin/sfncli || true
+	@if [[ "$(SFNCLI_VERSION)" == "$(SFNCLI_INSTALLED)" ]]; then \
+		echo "Using latest sfncli version $(SFNCLI_VERSION)"; \
+	else \
+		echo "Updating sfncli..."; \
+		curl --retry 5 --fail --max-time 30 -o bin/sfncli -sL https://github.com/Clever/sfncli/releases/download/$(SFNCLI_VERSION)/sfncli-$(SFNCLI_VERSION)-$(SYSTEM)-amd64 && \
+		chmod +x bin/sfncli && \
+		echo "Successfully updated sfncli to $(SFNCLI_LATEST)" || \
+		{ echo "Failed to update sfncli"; exit 1; } \
+	;fi
 
 sfncli-update-makefile: ensure-curl-installed
 	@curl -o /tmp/sfncli.mk -sL https://raw.githubusercontent.com/Clever/sfncli/master/make/sfncli.mk


### PR DESCRIPTION
- Added retries to sfncli download
- Added 30sec timeout 
- Shows error message when download fails
- Return non-zero exit code if download fails

Jira: https://clever.atlassian.net/browse/INFRA-2875