### PR TITLE
Pass SIGINT to command on context cancellation

### DIFF
--- a/cmd/sfncli/runner.go
+++ b/cmd/sfncli/runner.go
@@ -176,6 +176,12 @@ func (t *TaskRunner) handleSignals(ctx context.Context) {
 	for {
 		select {
 		case <-ctx.Done():
+			if t.execCmd.Process == nil {
+				return
+			}
+			// send SIGINT to give the command an opportunity to clean up when cancellation occurs
+			pid := t.execCmd.Process.Pid
+			signalProcess(pid, os.Interrupt)
 			return
 		case sigReceived := <-sigChan:
 			if t.execCmd.Process == nil {


### PR DESCRIPTION
Some workers at Clever have long running, async requests with varying cost. Let's ensure that we allow workers to gracefully clean up any resources when a given job times out