### PR TITLE
add team tag to activities

### DIFF
--- a/VERSION
+++ b/VERSION
@@ -1,2 +1,2 @@
-v0.7.0
-Migrate to go modules.
+v0.7.1
+Add team tag to activities

--- a/cmd/sfncli/sfncli.go
+++ b/cmd/sfncli/sfncli.go
@@ -232,6 +232,9 @@ func tagsFromEnv() []*sfn.Tag {
 	if account := os.Getenv("_POD_ACCOUNT"); account != "" {
 		tags = append(tags, &sfn.Tag{Key: aws.String("pod-account"), Value: aws.String(account)})
 	}
+	if team := os.Getenv("_TEAM_OWNER"); team != "" {
+		tags = append(tags, &sfn.Tag{Key: aws.String("team"), Value: aws.String(team)})
+	}
 
 	return tags
 }


### PR DESCRIPTION
cloudwatch metric streams to datadog copies AWS tags over to metrics in datadog, and it'd be helpful for activity metrics to have a team tag to create team-specific alerts