### PR TITLE
Bugfix: Limit length of error fields per AWS limits.

### DIFF
--- a/VERSION
+++ b/VERSION
@@ -1,2 +1,2 @@
-v0.7.1
-Add team tag to activities
+v0.7.2
+Truncate error messages to fit within AWS limits.


### PR DESCRIPTION
Bugfix: Limit length of error fields per AWS limits.

AWS will return a validation error when trying to send a task failure with error or cause above
certain limits. sfncli should just defend itself against that by truncating.

Open to any feedback. Let me know also if you think `[truncated]` is too long - it's on the side of clarity compared to, say, `[...]`.