### PR TITLE
remove log that is never used

### DIFF
--- a/VERSION
+++ b/VERSION
@@ -1,2 +1,2 @@
-v0.7.2
-Truncate error messages to fit within AWS limits.
+v0.7.3
+Remove logs tracking start and end time of exec

--- a/cmd/sfncli/runner.go
+++ b/cmd/sfncli/runner.go
@@ -110,12 +110,6 @@ func (t *TaskRunner) Process(ctx context.Context, args []string, input string) e
 	// forward signals to the command, handle SIGTERM
 	go t.handleSignals(ctx)
 
-	if tmpDir == "" {
-		t.logger.TraceD("exec-command-start", logger.M{"args": args, "cmd": t.cmd})
-	} else {
-		t.logger.TraceD("exec-command-start", logger.M{"args": args, "cmd": t.cmd, "workdirectory": tmpDir})
-	}
-	start := time.Now()
 	if err := t.execCmd.Run(); err != nil {
 		stderr := strings.TrimSpace(stderrbuf.String())                  // remove trailing newline
 		customError, _ := parseCustomErrorFromStdout(stdoutbuf.String()) // ignore parsing errors
@@ -142,7 +136,6 @@ func (t *TaskRunner) Process(ctx context.Context, args []string, input string) e
 		}
 		return t.sendTaskFailure(TaskFailureUnknown{err})
 	}
-	t.logger.InfoD("exec-command-end", logger.M{"duration_ns": time.Since(start)})
 
 	// AWS / states language requires JSON output
 	taskOutput := taskOutputFromStdout(stdoutbuf.String())


### PR DESCRIPTION
`exec-command-start` was converted to `TraceD` 3 years ago but I am pretty sure that it is never used. `exec-command-end` is currently the 2nd highest indexed log title, it is also never used.

We can get similar data directly from aws and it is also synced with datadog + the workflows dashboard covers this already so we should just delete these logs