### PR TITLE
increase heartbeat interval to manage throttling

### DIFF
--- a/VERSION
+++ b/VERSION
@@ -1,2 +1,2 @@
-v0.7.3
-Remove logs tracking start and end time of exec
+v0.7.4
+Increase heartbeat interval to manage sfnapi SendTaskHeartbeat throttling

--- a/cmd/sfncli/sfncli.go
+++ b/cmd/sfncli/sfncli.go
@@ -268,7 +268,7 @@ func taskHeartbeatLoop(ctx context.Context, sfnapi sfniface.SFNAPI, token string
 	if err := sendTaskHeartbeat(ctx, sfnapi, token); err != nil {
 		return err
 	}
-	heartbeat := time.NewTicker(15 * time.Second)
+	heartbeat := time.NewTicker(20 * time.Second)
 	defer heartbeat.Stop()
 	for {
 		select {


### PR DESCRIPTION
## Link to JIRA
[Link to JIRA](https://clever.atlassian.net/browse/INFRANG-6403)

## Overview
- Staging load test was failing due to throttling error thrown by step fn API
- We have a bunch of these error going back weeks where the number of API calls exceeds the provisioned capacity for the sfnapi.SendTaskHeartbeat
- This change should reduce the number of API calls by increasing the interval between heartbeat requests

## Testing
- Changes the heartbeat interval
- Relevant metric to check: [link](https://us-west-2.console.aws.amazon.com/cloudwatch/home?region=us-west-2#metricsV2?graph=~(metrics~(~(~(expression~'m2*20*2a*2060~label~'Refill*20capacity*20per*20minute~id~'e1~yAxis~'right))~(~'AWS*2fStates~'ThrottledEvents~'APIName~'SendTaskHeartbeat~(yAxis~'right~id~'m1))~(~'.~'ProvisionedRefillRate~'.~'.~(yAxis~'right~stat~'Average~id~'m2~visible~false))~(~'.~'ConsumedCapacity~'.~'.~(yAxis~'right~id~'m4)))~view~'timeSeries~stacked~false~region~'us-west-2~stat~'Sum~period~60~start~'-PT72H~end~'P0D)&query=~'*7bAWS*2fStates*2cAPIName*7d)
- Verify post rollout 

## Rollout

## Rollback (in the event of a problem)
- [ ] Rollback via dapple OR `ark rollback -e production qlayer-mvp`?
- [ ] Anything else?
