### PR TITLE
Followup to increase heartbeat interval

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -31,8 +31,7 @@ release:
 -o="$@/$(EXECUTABLE)-$(VERSION)-linux-amd64" $(EXECUTABLE_PKG)
 	GOOS=darwin GOARCH=amd64 go build -ldflags="-s -w -X main.Version=$(VERSION)" \
 -o="$@/$(EXECUTABLE)-$(VERSION)-darwin-amd64" $(EXECUTABLE_PKG)
-	GOOS=darwin GOARCH=arm64 go build -ldflags="-s -w -X main.Version=$(VERSION)" \
--o="$@/$(EXECUTABLE)-$(VERSION)-darwin-arm64" $(EXECUTABLE_PKG)
+	
 clean:
 	rm -rf bin release
 

--- a/cmd/sfncli/runner.go
+++ b/cmd/sfncli/runner.go
@@ -165,7 +165,7 @@ func (t *TaskRunner) Process(ctx context.Context, args []string, input string) e
 }
 
 func (t *TaskRunner) handleSignals(ctx context.Context) {
-	sigChan := make(chan os.Signal)
+	sigChan := make(chan os.Signal, 1)
 	signal.Notify(sigChan)
 	defer signal.Stop(sigChan)
 	for {


### PR DESCRIPTION
## Link to JIRA
[Link to JIRA](https://clever.atlassian.net/browse/INFRANG-6403)

## Overview
- Followup to https://github.com/Clever/sfncli/pull/114 (was failing master merge)

## Testing
- Changes the heartbeat interval
- Relevant metric to check: [link](https://us-west-2.console.aws.amazon.com/cloudwatch/home?region=us-west-2#metricsV2?graph=~(metrics~(~(~(expression~'m2*20*2a*2060~label~'Refill*20capacity*20per*20minute~id~'e1~yAxis~'right))~(~'AWS*2fStates~'ThrottledEvents~'APIName~'SendTaskHeartbeat~(yAxis~'right~id~'m1))~(~'.~'ProvisionedRefillRate~'.~'.~(yAxis~'right~stat~'Average~id~'m2~visible~false))~(~'.~'ConsumedCapacity~'.~'.~(yAxis~'right~id~'m4)))~view~'timeSeries~stacked~false~region~'us-west-2~stat~'Sum~period~60~start~'-PT72H~end~'P0D)&query=~'*7bAWS*2fStates*2cAPIName*7d)
- Verify post rollout 

## Context for the sigChan fix

building with go1.21 throws an error without this fix:
`cmd/sfncli/runner.go:169:2: misuse of unbuffered os.Signal channel as argument to signal.Notify
`

If the channel were unbuffered (i.e., make(chan os.Signal)), and a signal arrived when the program was not in the select block, that signal would be lost. This is because sending to an unbuffered channel blocks until a receiver is ready, and there would be no receiver ready if the program is not in the select block.
So, a buffer of 1 makes sense here because it ensures that no signals are lost if they arrive at an inconvenient time. There’s generally no need for a larger buffer, because signals are not usually sent in rapid succession, and the program processes each signal immediately upon receiving it.

## Rollout

## Rollback (in the event of a problem)
- [ ] Rollback via dapple OR `ark rollback -e production qlayer-mvp`?
- [ ] Anything else?
