### PR TITLE
go 1.21 update

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -9,7 +9,7 @@ EXECUTABLE_PKG := github.com/Clever/sfncli/cmd/sfncli
 
 .PHONY: all test $(PKGS) build install_deps release clean mocks
 
-$(eval $(call golang-version-check,1.13))
+$(eval $(call golang-version-check,1.21))
 
 all: test build release
 

--- a/VERSION
+++ b/VERSION
@@ -1,2 +1,2 @@
-v0.7.4
-Increase heartbeat interval to manage sfnapi SendTaskHeartbeat throttling
+v0.8.0
+Go 1.21 update


### PR DESCRIPTION

## Link to JIRA
https://clever.atlassian.net/browse/INFRANG-6568

## Overview
Proper release of the go 1.21 update along with minor version bump. 

## Testing

This was tested as a pre-release

## Rollout
Release as latest and then pull into workers. 