### PR TITLE
remove arch var from sfncli.ml

### DIFF
--- a/make/sfncli.mk
+++ b/make/sfncli.mk
@@ -1,6 +1,6 @@
 # This is the default sfncli Makefile.
 # Please do not alter this file directly.
-SFNCLI_MK_VERSION := 0.1.4
+SFNCLI_MK_VERSION := 0.1.5
 SHELL := /bin/bash
 SYSTEM := $(shell uname -a | cut -d" " -f1 | tr '[:upper:]' '[:lower:]')
 SFNCLI_INSTALLED := $(shell [[ -e "bin/sfncli" ]] && bin/sfncli --version)
@@ -11,7 +11,6 @@ SFNCLI_LATEST = $(shell \
 		https://api.github.com/repos/Clever/sfncli/releases/latest | \
 	grep tag_name | \
 	cut -d\" -f4)
-ARCH = $(shell go env GOARCH)
 
 .PHONY: bin/sfncli sfncli-update-makefile ensure-sfncli-version-set ensure-curl-installed
 
@@ -36,7 +35,7 @@ bin/sfncli: ensure-sfncli-version-set ensure-curl-installed
 		} \
 	else \
 		echo "Updating sfncli..."; \
-		curl --retry 5 --fail --max-time 30 -o bin/sfncli -sL https://github.com/Clever/sfncli/releases/download/$(SFNCLI_VERSION)/sfncli-$(SFNCLI_VERSION)-$(SYSTEM)-$(ARCH) && \
+		curl --retry 5 --fail --max-time 30 -o bin/sfncli -sL https://github.com/Clever/sfncli/releases/download/$(SFNCLI_VERSION)/sfncli-$(SFNCLI_VERSION)-$(SYSTEM)-amd64 && \
 		chmod +x bin/sfncli && \
 		echo "Successfully updated sfncli to $(SFNCLI_VERSION)" || \
 		{ [[ -z "$(SFNCLI_INSTALLED)" ]] && \


### PR DESCRIPTION
## Link to JIRA
https://clever.atlassian.net/browse/INFRANG-6600

## Overview
remove arch from sfncli.mk it's breaking things

This was a poorly thought through attempt at getting an sfncli that we build to work on m1 macs etc, but it didn’t work and broke other things so 🪓 


## Testing
```bash
circleci@5fe17d98359f:~/go/src/github.com/Clever/redshift-to-postgres$ make build
rm -f bin/redshift-to-postgres
Checking for sfncli updates...
Updating sfncli...
Successfully updated sfncli to v0.8.0
mkdir -p bin
cp config.yml bin/config.yml
cp snowflake-config.yml bin/snowflake-config.yml
cp kvconfig.yml bin/
go build -o bin/redshift-to-postgres github.com/Clever/redshift-to-postgres
```

## Rollout
Merge
For repos erroring when getting sfncli have them run
`make sfncli-update-makefile`