### PR TITLE
ASOC-710 Implemented the --inputfile flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,8 @@ Usage of sfncli:
     	The worker name to send to AWS Step Functions when processing a task. Environment variables are expanded. The magic string MAGIC_ECS_TASK_ARN will be expanded to the ECS task ARN via the metadata service.
   -workdirectory string
     	A directory path that is passed to the `cmd` using an env var `WORK_DIR`. For each activity task a new directory is created in `workdirectory` and it is cleaned up after the activity task exits. Defaults to "", does not create directory or set `WORK_DIR`
+  -inputfile
+    	Write task input to a file (input.json) in WORK_DIR instead of passing as CLI argument. Useful for avoiding ARG_MAX limits with large payloads. Requires -workdirectory to be set.
 ```
 
 Example:
@@ -34,7 +36,7 @@ sfncli -activityname sleep-100 -region us-west-2 --cloudwatchregion us-west-1 -w
 - On startup, call [`CreateActivity`](http://docs.aws.amazon.com/step-functions/latest/apireference/API_CreateActivity.html) to register an [Activity](http://docs.aws.amazon.com/step-functions/latest/dg/concepts-activities.html) with Step Functions.
 - Begin polling [`GetActivityTask`](http://docs.aws.amazon.com/step-functions/latest/apireference/API_GetActivityTask.html) for tasks.
 - Get a task. Take the JSON input for the task and
-  - if it's a JSON object, use this as the last arg to the `cmd` passed to `sfncli`.
+  - if it's a JSON object, use this as the last arg to the `cmd` passed to `sfncli` (unless `-inputfile` is set, in which case write it to `WORK_DIR/input.json` and pass the file path as the argument).
   - if it's anything else (e.g. JSON array), an error is thrown.
   - if `_EXECUTION_NAME` is missing from the payload, an error is thrown
   - the `_EXECUTION_NAME` payload attribute value is added to the environment of the `cmd` as `_EXECUTION_NAME`.

--- a/cmd/sfncli/runner_test.go
+++ b/cmd/sfncli/runner_test.go
@@ -72,7 +72,7 @@ func TestTaskFailureTaskInputNotJSON(t *testing.T) {
 		Error:     aws.String(expectedError.ErrorName()),
 		TaskToken: aws.String(mockTaskToken),
 	})
-	taskRunner := NewTaskRunner(path.Join(testScriptsDir, cmd), mockSFN, mockTaskToken, "")
+	taskRunner := NewTaskRunner(path.Join(testScriptsDir, cmd), mockSFN, mockTaskToken, "", false)
 	err := taskRunner.Process(testCtx, cmdArgs, taskInput)
 	require.Equal(t, err, expectedError)
 }
@@ -92,7 +92,7 @@ func TestTaskOutputEmptyStringAsJSON(t *testing.T) {
 		TaskToken: aws.String(mockTaskToken),
 		Output:    aws.String(`{"_EXECUTION_NAME":"fake-WFM-uuid"}`),
 	})
-	taskRunner := NewTaskRunner(path.Join(testScriptsDir, cmd), mockSFN, mockTaskToken, "")
+	taskRunner := NewTaskRunner(path.Join(testScriptsDir, cmd), mockSFN, mockTaskToken, "", false)
 	err := taskRunner.Process(testCtx, cmdArgs, taskInput)
 	require.NoError(t, err)
 
@@ -114,7 +114,7 @@ func TestTaskFailureCommandNotFound(t *testing.T) {
 		Error:     aws.String(expectedError.ErrorName()),
 		TaskToken: aws.String(mockTaskToken),
 	})
-	taskRunner := NewTaskRunner(path.Join(testScriptsDir, cmd), mockSFN, mockTaskToken, "")
+	taskRunner := NewTaskRunner(path.Join(testScriptsDir, cmd), mockSFN, mockTaskToken, "", false)
 	err := taskRunner.Process(testCtx, cmdArgs, emptyTaskInput)
 	require.Equal(t, err, expectedError)
 }
@@ -135,7 +135,7 @@ func TestTaskFailureCommandKilled(t *testing.T) {
 		Error:     aws.String(expectedError.ErrorName()),
 		TaskToken: aws.String(mockTaskToken),
 	})
-	taskRunner := NewTaskRunner(path.Join(testScriptsDir, cmd), mockSFN, mockTaskToken, "")
+	taskRunner := NewTaskRunner(path.Join(testScriptsDir, cmd), mockSFN, mockTaskToken, "", false)
 	go func() {
 		time.Sleep(2 * time.Second)
 		taskRunner.execCmd.Process.Signal(syscall.SIGKILL)
@@ -160,7 +160,7 @@ func TestTaskFailureCommandExitedNonzero(t *testing.T) {
 		Error:     aws.String(expectedError.ErrorName()),
 		TaskToken: aws.String(mockTaskToken),
 	})
-	taskRunner := NewTaskRunner(path.Join(testScriptsDir, cmd), mockSFN, mockTaskToken, "")
+	taskRunner := NewTaskRunner(path.Join(testScriptsDir, cmd), mockSFN, mockTaskToken, "", false)
 	err := taskRunner.Process(testCtx, cmdArgs, emptyTaskInput)
 	require.Equal(t, err, expectedError)
 }
@@ -181,7 +181,7 @@ func TestTaskFailureCustomErrorName(t *testing.T) {
 		Error:     aws.String(expectedError.ErrorName()),
 		TaskToken: aws.String(mockTaskToken),
 	})
-	taskRunner := NewTaskRunner(path.Join(testScriptsDir, cmd), mockSFN, mockTaskToken, "")
+	taskRunner := NewTaskRunner(path.Join(testScriptsDir, cmd), mockSFN, mockTaskToken, "", false)
 	err := taskRunner.Process(testCtx, cmdArgs, emptyTaskInput)
 	require.Equal(t, err, expectedError)
 }
@@ -202,7 +202,7 @@ func TestTaskFailureTaskOutputNotJSON(t *testing.T) {
 		Error:     aws.String(expectedError.ErrorName()),
 		TaskToken: aws.String(mockTaskToken),
 	})
-	taskRunner := NewTaskRunner(path.Join(testScriptsDir, cmd), mockSFN, mockTaskToken, "")
+	taskRunner := NewTaskRunner(path.Join(testScriptsDir, cmd), mockSFN, mockTaskToken, "", false)
 	err := taskRunner.Process(testCtx, cmdArgs, emptyTaskInput)
 	require.Equal(t, err, expectedError)
 }
@@ -223,7 +223,7 @@ func TestTaskFailureCommandTerminated(t *testing.T) {
 			Error:     aws.String(expectedError.ErrorName()),
 			TaskToken: aws.String(mockTaskToken),
 		})
-		taskRunner := NewTaskRunner(path.Join(testScriptsDir, cmd), mockSFN, mockTaskToken, "")
+		taskRunner := NewTaskRunner(path.Join(testScriptsDir, cmd), mockSFN, mockTaskToken, "", false)
 		go func() {
 			time.Sleep(1 * time.Second)
 			process, _ := os.FindProcess(os.Getpid())
@@ -248,7 +248,7 @@ func TestTaskFailureCommandTerminated(t *testing.T) {
 			Error:     aws.String(expectedError.ErrorName()),
 			TaskToken: aws.String(mockTaskToken),
 		})
-		taskRunner := NewTaskRunner(path.Join(testScriptsDir, cmd), mockSFN, mockTaskToken, "")
+		taskRunner := NewTaskRunner(path.Join(testScriptsDir, cmd), mockSFN, mockTaskToken, "", false)
 		go func() {
 			time.Sleep(1 * time.Second)
 			process, _ := os.FindProcess(os.Getpid())
@@ -273,7 +273,7 @@ func TestTaskFailureCommandTerminated(t *testing.T) {
 			Error:     aws.String(expectedError.ErrorName()),
 			TaskToken: aws.String(mockTaskToken),
 		})
-		taskRunner := NewTaskRunner(path.Join(testScriptsDir, cmd), mockSFN, mockTaskToken, "")
+		taskRunner := NewTaskRunner(path.Join(testScriptsDir, cmd), mockSFN, mockTaskToken, "", false)
 		// lower the grace period so this test doesn't take forever
 		taskRunner.sigtermGracePeriod = 5 * time.Second
 		go func() {
@@ -299,7 +299,7 @@ func TestTaskSuccessSignalForwarded(t *testing.T) {
 		TaskToken: aws.String(mockTaskToken),
 	})
 	defer controller.Finish()
-	taskRunner := NewTaskRunner(path.Join(testScriptsDir, cmd), mockSFN, mockTaskToken, "")
+	taskRunner := NewTaskRunner(path.Join(testScriptsDir, cmd), mockSFN, mockTaskToken, "", false)
 	go func() {
 		time.Sleep(1 * time.Second)
 		process, _ := os.FindProcess(os.Getpid())
@@ -321,7 +321,7 @@ func TestTaskSuccessOutputIsLastLineOfStdout(t *testing.T) {
 		TaskToken: aws.String(mockTaskToken),
 	})
 	defer controller.Finish()
-	taskRunner := NewTaskRunner(path.Join(testScriptsDir, cmd), mockSFN, mockTaskToken, "")
+	taskRunner := NewTaskRunner(path.Join(testScriptsDir, cmd), mockSFN, mockTaskToken, "", false)
 	require.Nil(t, taskRunner.Process(testCtx, cmdArgs, emptyTaskInput))
 }
 
@@ -340,7 +340,7 @@ func TestTaskWorkDirectorySetup(t *testing.T) {
 		taskToken:      mockTaskToken,
 		expectedPrefix: "/tmp",
 	}) // returns the result of WORK_DIR
-	taskRunner := NewTaskRunner(path.Join(testScriptsDir, cmd), mockSFN, mockTaskToken, "/tmp")
+	taskRunner := NewTaskRunner(path.Join(testScriptsDir, cmd), mockSFN, mockTaskToken, "/tmp", false)
 	err := taskRunner.Process(testCtx, cmdArgs, taskInput)
 	require.NoError(t, err)
 }
@@ -360,7 +360,7 @@ func TestTaskWorkDirectoryUnsetByDefault(t *testing.T) {
 		TaskToken: aws.String(mockTaskToken),
 		Output:    aws.String(`{"_EXECUTION_NAME":"fake-WFM-uuid","work_dir":""}`), // returns the result of WORK_DIR
 	})
-	taskRunner := NewTaskRunner(path.Join(testScriptsDir, cmd), mockSFN, mockTaskToken, "")
+	taskRunner := NewTaskRunner(path.Join(testScriptsDir, cmd), mockSFN, mockTaskToken, "", false)
 	err := taskRunner.Process(testCtx, cmdArgs, taskInput)
 	require.NoError(t, err)
 }
@@ -384,7 +384,7 @@ func TestTaskWorkDirectoryCleaned(t *testing.T) {
 
 	os.MkdirAll("/tmp/test", os.ModeDir|0777) // base path is created by cmd/sfncli/sfncli.go
 	defer os.RemoveAll("/tmp/test")
-	taskRunner := NewTaskRunner(path.Join(testScriptsDir, cmd), mockSFN, mockTaskToken, "/tmp/test")
+	taskRunner := NewTaskRunner(path.Join(testScriptsDir, cmd), mockSFN, mockTaskToken, "/tmp/test", false)
 	err := taskRunner.Process(testCtx, cmdArgs, taskInput)
 	require.NoError(t, err)
 	if _, err := os.Stat(dirMatcher.foundWorkdir); os.IsExist(err) {

--- a/cmd/sfncli/sfncli.go
+++ b/cmd/sfncli/sfncli.go
@@ -33,6 +33,7 @@ func main() {
 	region := flag.String("region", "", "The AWS region to send Step Function API calls. Defaults to AWS_REGION.")
 	cloudWatchRegion := flag.String("cloudwatchregion", "", "The AWS region to report metrics. Defaults to the value of the region flag.")
 	workDirectory := flag.String("workdirectory", "", "Create the specified directory pass the path using the environment variable WORK_DIR to the cmd processing a task. Default is to not create the path.")
+	inputFile := flag.Bool("inputfile", false, "Write task input to a file (input.json) in WORK_DIR instead of passing as CLI argument. Useful for avoiding ARG_MAX limits with large payloads.")
 	printVersion := flag.Bool("version", false, "Print the version and exit.")
 
 	flag.Parse()
@@ -214,7 +215,7 @@ func main() {
 
 			// Run the command. Treat unprocessed args (flag.Args()) as additional args to
 			// send to the command on every invocation of the command
-			taskRunner := NewTaskRunner(*cmd, sfnapi, token, *workDirectory)
+			taskRunner := NewTaskRunner(*cmd, sfnapi, token, *workDirectory, *inputFile)
 			err = taskRunner.Process(taskCtx, flag.Args(), input)
 			if err != nil {
 				log.ErrorD("task-process-error", logger.M{"error": err.Error()})

--- a/go.mod
+++ b/go.mod
@@ -9,6 +9,7 @@ require (
 	github.com/aws/aws-sdk-go-v2/config v1.29.17
 	github.com/aws/aws-sdk-go-v2/service/cloudwatch v1.32.2
 	github.com/aws/aws-sdk-go-v2/service/sfn v1.24.1
+	github.com/aws/smithy-go v1.22.4
 	github.com/golang/mock v1.6.0
 	github.com/stretchr/testify v1.8.0
 	golang.org/x/time v0.0.0-20190308202827-9d24e82272b4
@@ -26,7 +27,6 @@ require (
 	github.com/aws/aws-sdk-go-v2/service/sso v1.25.5 // indirect
 	github.com/aws/aws-sdk-go-v2/service/ssooidc v1.30.3 // indirect
 	github.com/aws/aws-sdk-go-v2/service/sts v1.34.0 // indirect
-	github.com/aws/smithy-go v1.22.4 // indirect
 	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/jmespath/go-jmespath v0.4.0 // indirect
 	github.com/kr/text v0.2.0 // indirect


### PR DESCRIPTION
/## Clever Coding Standards Agreement

- [ ] Author and Review Statement, "We agree this code adheres to our [Clever Global Coding Standards](https://app.getguru.com/folders/ibabX5oT/Engineering-Standards-Best-Practices?activeCard=a8a444f4-9149-4ec7-a0fd-8ba42519d93e) and other applicable [Coding Standards](https://app.getguru.com/folders/ibabX5oT/Engineering-Standards-Best-Practices)"

## Clever Coding Standards Agreement

- [ ] Author and Review Statement, "We agree this code adheres to our [Clever Global Coding Standards](https://app.getguru.com/folders/ibabX5oT/Engineering-Standards-Best-Practices?activeCard=a8a444f4-9149-4ec7-a0fd-8ba42519d93e) and other applicable [Coding Standards](https://app.getguru.com/folders/ibabX5oT/Engineering-Standards-Best-Practices)"

## JIRA
[ASOC-710](https://clever.atlassian.net/browse/ASOC-710)

## Overview
Implemented the --inputfile flag for sfncli to avoid ARG_MAX limits.

#### Changes

- **Added `--inputfile` flag** in `sfncli.go`:
  - Boolean flag that enables file-based input mode
  - Requires `--workdirectory` to be set (since we need a directory to write the file)

- **Updated `TaskRunner` struct** in `runner.go`:
  - Added `inputFile bool` field to track the mode
  - Updated `NewTaskRunner()` constructor to accept `inputFile` parameter

- **Modified `Process()` method** in `runner.go`:
  - When `inputFile` is enabled:
    - Validates that `workDirectory` is set (returns error if not)
    - Writes JSON input to `WORK_DIR/input.json` in the task's temporary directory
    - Passes the file path as the argument instead of raw JSON
  - When disabled: maintains existing behavior (passes JSON as CLI argument)
  - Added `path/filepath` import for file path operations

- **Updated `README.md`**:
  - Added `--inputfile` flag to the usage section
  - Updated high-level logic section to explain the new file-based input behavior

## Testing
- **Updated all test cases** in `runner_test.go`:
  - Modified all `NewTaskRunner()` calls to include the new `inputFile` parameter (set to `false` for existing tests to maintain backward compatibility)

## Rollout
This feature addresses the specific use case where the `api-v3-finalizer` worker processes migrations with thousands of district IDs. Payloads regularly exceed 100KB, hitting ARG_MAX limits. With this change, workers can read input from a file instead of parsing command-line arguments.

## Rollback
Should not affect existing feature.

[ASOC-710]: https://clever.atlassian.net/browse/ASOC-710?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ